### PR TITLE
SEP 0014 - AI Card Discovery

### DIFF
--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -149,6 +149,7 @@ The content and structure of metadata files referenced by `metadata.url` are **o
 - **A2A Agent Cards**: Already defined by the A2A specification. The A2A community maintains full control over this schema.
 
 This SEP **intentionally does not mandate** any particular structure for these metadata files. It only defines the discovery mechanism that points to them.
+The scope could be increased to also indicating the version(s) of the protocols and metadata files that are provided.
 
 ## Rationale
 

--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -41,6 +41,7 @@ Having separate protocol-specific endpoints creates additional friction:
 - **Multiple probes required**: Clients must try `/.well-known/agent.json`, then `/.well-known/mcp/server-card.json`, then future protocols
 - **N+1 HTTP requests**: One per protocol, with many failures for unsupported protocols
 - **No capability indication**: No standard way to discover what AI protocols a domain supports
+- **Duplicated standardization efforts**: Since MCP has not standardized yet how a .well-known discovery would work, going for AI Card discovery directly reduces one option for the ecosystem to support.
 
 ### This Proposal
 
@@ -125,7 +126,9 @@ Relative URLs are resolved **relative to the location of the discovery document*
 
 ### Metadata Files
 
-Each protocol community maintains **full ownership** of their metadata format. This SEP only defines the discovery mechanism that points to these files.
+Each protocol community maintains **full ownership** of their metadata format. 
+The attached metadata files remain fully self-contained.
+This SEP only defines the discovery mechanism that points to these files.
 
 #### Protocol-Specific Metadata Formats
 
@@ -211,7 +214,7 @@ Do we have to support public and internal metadata (internal could be richer)?
 
 **Options**:
 - **A)** Allow dynamic generation of discovery document and metadata files
-- **B)** Use query parameters: `/.well-known/ai-cards.json?tenant=acme`
+- **B)** Use query/header params or bearer token
 - **C)** Document that discovery is static; dynamic capabilities in metadata files
 
 ### 4. Metadata that is not tied to an API protocol
@@ -220,6 +223,13 @@ Do we have to support public and internal metadata (internal could be richer)?
 
 Examples: 
 - https://github.com/edp-protocol/entity-discovery-protocol
+
+### 5. Add lightweight shared model with public information to the discovery document? 
+
+A few more field could be added to the discovery document to provide public information about the service, such as:
+- ID / Name
+- Short Description
+- Links (to documentation, terms of service, etc.)
 
 ## Alternatives Considered
 
@@ -321,7 +331,11 @@ A2A has defined [`/.well-known/agent.json`](https://a2a-protocol.org/latest/spec
 | **Protocol Awareness** | Protocol-agnostic, undefined | Protocol-specific (`type: mcp` vs `type: a2a`) |
 | **Metadata** | Links to OpenAPI specs, generic docs | Links to AI-specific card formats (MCP Server Cards, A2A Agent Cards) |
 
-**Relationship**: RFC 9727 is too generic for AI protocol discovery. It does neither state which protocol nor which metadata format is provided, just a generic MIME type. This SEP provides AI-specific protocol identification and metadata.
+**Relationship**: RFC 9727 is too generic for AI protocol discovery. 
+It does neither state which protocol nor which metadata format is provided, just a generic MIME type. 
+This SEP provides AI-specific protocol identification and metadata.
+
+**Counterargument**: We could register a more precise MIME type for the AI protocol metadata formats (e.g. `application/a2a-agent-card+json`), making this approach work better (although still no protocol defined).
 
 ### Open Resource Discovery: `.well-known/open-resource-discovery`
 
@@ -348,7 +362,7 @@ This proposal assumes that for the AI ecosystem a simpler approach is desired an
 **Coexistence options:**
 - **Enterprise environments**: Use ORD for comprehensive discovery
 - **AI-focused environments**: Use lightweight `/.well-known/ai-cards.json`
-- **Hybrid deployments**: Implement both as needed
+- **Hybrid deployments**: Implement both as needed, only AI Card when describing pure Agents / MCP Servers. 
 
 ## Links
 

--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -156,6 +156,7 @@ The scope could be increased to also indicating the version(s) of the protocols 
 ### Why a Well-Known URI?
 
 The `.well-known` URI scheme ([RFC 8615](https://www.rfc-editor.org/rfc/rfc8615)) is a well-established standard for service discovery, making it a natural fit for AI Card discovery. It allows clients to probe a service for capabilities without prior configuration.
+Compared to a centralized registry push model, this approach provides local self-description and a decentralized discovery mechanism.
 
 ### Why Not a Shared Model?
 

--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -73,6 +73,8 @@ This SEP addresses these challenges by:
 
 Services supporting AI Card discovery MUST provide a JSON document at `/.well-known/ai-cards.json`.
 
+By appending `.json` it is easier to host this and the linked metadata files on a static file server.
+
 ### Discovery Document Format
 
 The discovery document MUST be a JSON object following the [ai-card-v0.schema.json](./0000-ai-card-discovery.schema.json) schema.
@@ -82,19 +84,28 @@ The discovery document MUST be a JSON object following the [ai-card-v0.schema.js
   "$schema": "https://ai-card.org/schemas/ai-card-v0.schema.json",
   "protocols": [
     {
-      "protocolType": "a2a",
+      "type": "a2a",
       "endpoints": [{"url": "https://example.com/a2a-endpoint"}],
-      "metadata": {"url": "https://example.com/.well-known/PetAgent.json"}
+      "metadata": {
+        "type": "agent-card",
+        "url": "https://example.com/.well-known/PetAgent.json"
+      }
     },
     {
-      "protocolType": "mcp",
+      "type": "mcp",
       "endpoints": [{"url": "https://example.com/mcp-endpoint"}],
-      "metadata": {"url": "https://example.com/.well-known/petstore.mcp.json"}
+      "metadata": {
+        "type": "mcp-server-card",
+        "url": "https://example.com/.well-known/petstore.mcp.json"
+      }
     },
     {
-      "protocolType": "mcp",
+      "type": "mcp",
       "endpoints": [{"url": "https://example.com/mcp-endpoint-inventory"}],
-      "metadata": {"url": "https://example.com/.well-known/inventory.mcp.json"}
+      "metadata": {
+        "type": "mcp-server-card",
+        "url": "https://example.com/.well-known/inventory.mcp.json"
+      }
     }
   ]
 }
@@ -122,20 +133,6 @@ Relative URLs are resolved **relative to the location of the discovery document*
 **Absolute-path URLs** (start with `/`):
 - `/api/mcp` → resolves to `/api/mcp` (relative to host root)
 - `/metadata/petstore.mcp.json` → resolves to `/metadata/petstore.mcp.json`
-
-**Examples:**
-
-```json
-{
-  "protocols": [
-    {
-      "protocolType": "mcp",
-      "endpoints": [{"url": "./mcp"}],
-      "metadata": {"url": "./petstore.mcp.json"}
-    }
-  ]
-}
-```
 
 For a discovery document served at `https://example.com/.well-known/ai-cards.json`:
 - `./mcp` resolves to `https://example.com/.well-known/mcp`
@@ -232,7 +229,7 @@ This is a new feature and does not introduce backward compatibility concerns. Se
 
 2. **Metadata Definition Versioning**: Should there be a mechanism to indicate which version of the metadata definition format is being used?
 
-3. **Multiple Versions**: If a service supports multiple versions of a protocol, should they be separate entries in the `protocols` array or should version information be embedded in each protocol object?
+3. **Multiple Versions**: If a service supports multiple versions of a protocol, should they be separate entries in `protocols` (e.g. "a2a-v1", "a2a-v2") and metadata types ("a2a-agent-card-v1", "a2a-agent-card-v2") or should version information be only available by actually fetching the metadata files / connecting to the endpoints?
 
 4. **Coordination with MCP SEP-2127**: Should this SEP be proposed to the MCP community, or should it be maintained as a separate cross-protocol specification? If the latter, how do we ensure adoption across both ecosystems?
 
@@ -366,8 +363,8 @@ RFC 9727 defines a well-known URI for discovering **any** APIs published by a do
    - This SEP: **AI-native protocol discovery** - specifically for MCP servers and A2A agents
 
 2. **Protocol Awareness**:
-   - RFC 9727: **Protocol-agnostic** - doesn't specify what protocol the APIs use (only mediaType like `application/json`)
-   - This SEP: **Protocol-specific** - explicitly identifies `protocolType` (mcp, a2a) and links to protocol-specific metadata
+   - RFC 9727: **Protocol-agnostic** - doesn't specify what protocol or metadata format the APIs use (only mediaType like `application/json`)
+   - This SEP: **Protocol-specific** - explicitly identifies `protocolType` (mcp, a2a) and the metadata format and links to protocol-specific metadata
 
 3. **Metadata Structure**:
    - RFC 9727: Links to generic metadata (OpenAPI specs, docs) using standard link relations
@@ -414,7 +411,7 @@ ORD is an **enterprise-grade** discovery protocol that provides comprehensive re
 
 3. **Adoption Barrier**:
    - ORD: Requires understanding extensive specification, implementing complex data models
-   - This SEP: Small JSON Schema contract, 3 required fields
+   - This SEP: Small JSON Schema contract, 5 required fields per protocol (type, endpoints, metadata with type and url)
    - Lower barrier → faster ecosystem adoption
 
 4. **Protocol Specificity**:

--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -213,7 +213,12 @@ Should the protocol `type` field include version information (e.g., `"mcp/v1"`, 
 - **B)** Use query parameters: `/.well-known/ai-cards.json?tenant=acme`
 - **C)** Document that discovery is static; dynamic capabilities in metadata files
 
-**Security consideration**: Tenant isolation and information disclosure.
+### 4. Metadata that is not tied to an API protocol
+
+**Question**: Should metadata that is not tied to an API protocol implementation be discoverable? Do we see use-cases for this?
+
+Examples: 
+- https://github.com/edp-protocol/entity-discovery-protocol
 
 ## Alternatives Considered
 
@@ -222,6 +227,7 @@ Should the protocol `type` field include version information (e.g., `"mcp/v1"`, 
 Creating a single card format that both MCP and A2A adopt. Proposal is to reject this due to the coordination overhead and risk of creating yet another standard.
 
 ### Protocol-Specific Discovery (Status Quo)
+
 Having each protocol define its own discovery mechanism:
 - MCP: `/.well-known/mcp/server-card.json` ([SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127))
 - A2A: `/.well-known/a2a/agent-card.json` (proposed)

--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -327,7 +327,8 @@ A2A has defined [`/.well-known/agent.json`](https://a2a-protocol.org/latest/spec
 [ORD](https://open-resource-discovery.org/spec-v1) (Linux Foundation) is an enterprise-grade discovery protocol for APIs, events, data products, domain objects, and taxonomy.
 
 **ORD capabilities include:**
-- Comprehensive resource types (APIs, events, data products, domain objects)
+- Multiple resource types and protocols supported (APIs, events, data products, agents, lightweight system landscape model)
+- Includes defining and linking of taxonomies and business-concepts (vendors, products, domain / business objects) 
 - Static vs dynamic perspectives (system-type vs tenant-specific)
 - Aggregation across multi-system landscapes
 - Access strategies and governance

--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -1,0 +1,443 @@
+---
+SEP: 0000
+Title: AI Card Discovery via Well-Known URI
+Author: [Simon Heimler] <simon.heimler@sap.com>
+Status: draft
+Type: Standards Track
+Created: 2026-01-24
+---
+
+## Abstract
+
+This SEP proposes a standardized discovery mechanism for AI native protocols and their metadata through a [.well-known URI](https://www.rfc-editor.org/rfc/rfc8615) endpoint (`/.well-known/ai-cards.json`). This solves the discovery problem that both [MCP](https://modelcontextprotocol.io) (Model Context Protocol) and [A2A](https://a2a-protocol.org) (Agent-to-Agent) protocols face, eliminating the need for each protocol to define its own discovery mechanism independently.
+
+The proposal recognizes that:
+- **A2A** has defined [`/.well-known/agent.json`](https://github.com/protocol-registries/well-known-uris/issues/66) for discovery, but assumes **one agent per host**
+- **MCP Server Cards** need to evolve from the existing MCP Registry `server.json` format to include tools, prompts, and resources, proposed as [MCP Server Cards (SEP-2127)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127), with discovery at `/.well-known/mcp/server-card.json` assuming **one server per host**
+- Both protocols face the **same limitation**: the single-service assumption doesn't fit real-world multi-service deployments
+- **Discovery** is a shared concern that benefits from a unified, multi-service approach
+- **Future-proofing**: The discovery mechanism is designed to support future AI protocols, versions and their metadata formats
+
+By providing a protocol-agnostic discovery layer, this SEP enables a single host to advertise multiple MCP servers and/or multiple A2A agents, while allowing each protocol to maintain full ownership of their card formats, keeping their own autonomy and lifecycle.
+
+## Motivation
+
+### The Current Landscape
+
+**A2A** has defined [`/.well-known/agent.json`](https://github.com/protocol-registries/well-known-uris/issues/66) for agent discovery, with A2A Agent Cards providing comprehensive metadata about agents. However, the endpoint assumes **one agent per host** and the discovery mechanism is exclusive to A2A.
+
+**MCP** has proposed [SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127) defining `/.well-known/mcp/server-card.json` for server discovery, with comprehensive server metadata. However, it also assumes **one MCP server per host** and the discovery mechanism is exclusive to MCP.
+
+Both protocols also have existing metadata formats:
+- **A2A Agent Cards**: Already well-defined for agent metadata
+- **MCP Registry `server.json`**: Exists for registry entries but is incomplete (missing tools, prompts, resources)
+
+In reality, a single host can and should be able to expose:
+- Multiple MCP servers (e.g., a petstore server and an inventory server)
+- Multiple A2A agents (e.g., a customer service agent and a sales agent)
+- A mix of both protocols
+
+### The Single-Service Assumption Problem
+
+**Both A2A and MCP discovery mechanisms share the same critical limitation:**
+- A2A: `/.well-known/agent.json` (singular) → assumes one agent
+- MCP: `/.well-known/mcp/server-card.json` (singular) → assumes one server
+
+This breaks down in real-world scenarios:
+- A company may host multiple specialized agents (sales, support, analytics)
+- A domain may host multiple distinct MCP servers (petstore, inventory, analytics)
+- A platform may provide both MCP servers and A2A agents
+- Registries need to discover all available services, not just the "primary" one
+
+### The Multi-Protocol Discovery Problem
+
+Beyond the single-service limitation, having separate protocol-specific discovery endpoints creates additional friction:
+- **Clients must probe multiple endpoints**: Try `/.well-known/agent.json`, then `/.well-known/mcp/server-card.json`, then future protocols
+- **Registries must implement multiple discovery protocols**: Each protocol adds complexity
+- **No standard way to discover what protocols a domain supports**: Clients must guess and try each one
+- **N+1 HTTP requests**: One request per protocol, with failures for unsupported ones
+
+### This Proposal
+
+This SEP addresses these challenges by:
+
+1. **Solving discovery once**: Provides a single, protocol-agnostic discovery mechanism
+2. **Avoiding model proliferation**: Each protocol maintains its own card definitions (A2A Agent Cards, MCP Server Cards)
+3. **Supporting multiple servers/agents**: Explicitly designed for hosts exposing multiple services
+4. **Reducing coordination overhead**: Protocols only need to agree on discovery, not on card formats
+5. **Simplifying the ecosystem**: One endpoint to discover all AI capabilities on a domain
+
+## Specification
+
+### Well-Known URI
+
+Services supporting AI Card discovery MUST provide a JSON document at `/.well-known/ai-cards.json`.
+
+### Discovery Document Format
+
+The discovery document MUST be a JSON object following the [ai-card-v0.schema.json](./0000-ai-card-discovery.schema.json) schema.
+
+```json
+{
+  "$schema": "https://ai-card.org/schemas/ai-card-v0.schema.json",
+  "protocols": [
+    {
+      "protocolType": "a2a",
+      "endpoints": [{"url": "https://example.com/a2a-endpoint"}],
+      "metadata": {"url": "https://example.com/.well-known/PetAgent.json"}
+    },
+    {
+      "protocolType": "mcp",
+      "endpoints": [{"url": "https://example.com/mcp-endpoint"}],
+      "metadata": {"url": "https://example.com/.well-known/petstore.mcp.json"}
+    },
+    {
+      "protocolType": "mcp",
+      "endpoints": [{"url": "https://example.com/mcp-endpoint-inventory"}],
+      "metadata": {"url": "https://example.com/.well-known/inventory.mcp.json"}
+    }
+  ]
+}
+```
+
+**Note**: A single host can expose multiple MCP servers or multiple A2A agents. Each should be listed as a separate entry in the `protocols` array, as shown in the example above where two different MCP servers (petstore and inventory) are hosted on the same domain.
+
+### URL Resolution
+
+URLs in the discovery document (both `endpoints[].url` and `metadata.url`) **MAY be relative or absolute**.
+
+#### Absolute URLs
+Absolute URLs include the full protocol and authority:
+- `https://example.com/mcp-endpoint`
+- `https://api.example.com/.well-known/petstore.mcp.json`
+
+#### Relative URLs
+Relative URLs are resolved **relative to the location of the discovery document** (`/.well-known/ai-cards.json`), following [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) URL resolution rules:
+
+**Path-relative URLs** (start with `./` or `../`):
+- `./petstore.mcp.json` → resolves to `/.well-known/petstore.mcp.json`
+- `./mcp-endpoint` → resolves to `/.well-known/mcp-endpoint`
+- `../metadata/server.json` → resolves to `/metadata/server.json`
+
+**Absolute-path URLs** (start with `/`):
+- `/api/mcp` → resolves to `/api/mcp` (relative to host root)
+- `/metadata/petstore.mcp.json` → resolves to `/metadata/petstore.mcp.json`
+
+**Examples:**
+
+```json
+{
+  "protocols": [
+    {
+      "protocolType": "mcp",
+      "endpoints": [{"url": "./mcp"}],
+      "metadata": {"url": "./petstore.mcp.json"}
+    }
+  ]
+}
+```
+
+For a discovery document served at `https://example.com/.well-known/ai-cards.json`:
+- `./mcp` resolves to `https://example.com/.well-known/mcp`
+- `./petstore.mcp.json` resolves to `https://example.com/.well-known/petstore.mcp.json`
+
+**Recommendation**: Use relative URLs when metadata and endpoints are co-located with the discovery document. Use absolute URLs when pointing to external services or different domains.
+
+### Metadata Files
+
+The content and structure of metadata files referenced by `metadata.url` are **owned and defined by their respective protocol communities**:
+
+- **MCP Server Cards**: Should evolve from the existing [MCP Registry `server.json` format](https://github.com/modelcontextprotocol/registry) ([JSON Schema](https://github.com/modelcontextprotocol/registry/blob/main/internal/validators/schemas/2025-12-11.json)), enhanced with tools, prompts, and resources as proposed in [SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127). The MCP community maintains full control over this schema.
+
+- **A2A Agent Cards**: Already defined by the A2A specification. The A2A community maintains full control over this schema.
+
+This SEP **intentionally does not mandate** any particular structure for these metadata files. It only defines the discovery mechanism that points to them.
+
+## Rationale
+
+### Why a Well-Known URI?
+
+The `.well-known` URI scheme ([RFC 8615](https://www.rfc-editor.org/rfc/rfc8615)) is a well-established standard for service discovery, making it a natural fit for AI Card discovery. It allows clients to probe a service for capabilities without prior configuration.
+
+### Why Not a Shared Model?
+
+Creating a shared model between MCP and A2A would require:
+
+1. Ongoing coordination between protocol groups
+2. Libraries to support an additional standard
+3. Potential compromises that don't serve either protocol well
+4. Slower evolution as changes require multi-party consensus
+
+By keeping card definitions protocol-specific, each group maintains autonomy while still enabling discovery.
+
+### Minimal Coordination Surface
+
+This proposal minimizes the coordination surface to just three pieces of information:
+1. Protocol type identifier (`protocolType`)
+2. Where to connect (`endpoints`)
+3. Where to find metadata (`metadata`)
+
+This allows protocols to evolve their metadata formats independently.
+
+### Relationship to Existing Discovery Mechanisms
+
+Both MCP and A2A have defined protocol-specific discovery endpoints:
+
+**A2A: `/.well-known/agent.json`**
+- **Status**: [Registered with IANA](https://github.com/protocol-registries/well-known-uris/issues/66)
+- **Specification**: [A2A Protocol](https://a2a-protocol.org/latest/specification/)
+- **Limitation**: Assumes one agent per host (singular `agent.json`)
+
+**MCP: `/.well-known/mcp/server-card.json`** 
+- **Status**: [Proposed in SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127)
+- **Limitation**: Assumes one MCP server per host
+
+**This SEP addresses the shared limitations:**
+
+1. **Supporting multiple services per host**: The `protocols` array can list many MCP servers and/or A2A agents
+2. **Enabling multi-protocol discovery**: A single request reveals all available AI services
+3. **Avoiding discovery fragmentation**: One shared endpoint instead of N protocol-specific endpoints
+4. **Backward compatibility**: Can coexist with protocol-specific endpoints (see Integration Path in Alternatives)
+
+### MCP Server Card Format Evolution
+
+This SEP **does not define** the MCP Server Card format itself. Instead MCP Server Cards should evolve to:
+- Ideally merge with the existing MCP Registry `server.json` format, by adding the missing elements. We should avoid having two different formats to describe an MCP server, depending on where/how we publish. MCP Server Cards could be a convention on top of the existing format, describing which elements are required and optional.
+- **Remain MCP-owned**: The MCP community maintains full control over the MCP Server Card schema
+- **Be discoverable via** this shared `/.well-known/ai-cards.json` mechanism
+
+Similarly, **A2A Agent Cards** (already defined) would be discoverable through the same mechanism, allowing both protocols to evolve independently while sharing a common discovery layer.
+
+## Backward Compatibility
+
+This is a new feature and does not introduce backward compatibility concerns. Services that do not implement the well-known URI simply won't be discoverable through this mechanism.
+
+## Reference Implementation
+
+[To be provided]
+
+## Security Implications
+
+1. **HTTPS Required**: Implementations SHOULD require HTTPS for all URLs in the discovery document to prevent man-in-the-middle attacks
+
+2. **URL Validation**: Clients MUST validate that `metadata.url` and endpoint URLs are properly formatted URLs
+
+3. **Size Limits**: Implementations SHOULD enforce reasonable size limits on the discovery document (e.g., 2MB) to prevent denial-of-service attacks
+
+4. **Access Control**: Implementations SHOULD have an unprotected discovery document, but MAY implement access control for the linked metadata files
+
+## Open Questions
+
+1. **Versioning**: Should the protocol `type` field include version information (e.g., "mcp/v1", "a2a/v1")? Or should versioning be handled in the protocol-specific metadata files?
+
+2. **Metadata Definition Versioning**: Should there be a mechanism to indicate which version of the metadata definition format is being used?
+
+3. **Multiple Versions**: If a service supports multiple versions of a protocol, should they be separate entries in the `protocols` array or should version information be embedded in each protocol object?
+
+4. **Coordination with MCP SEP-2127**: Should this SEP be proposed to the MCP community, or should it be maintained as a separate cross-protocol specification? If the latter, how do we ensure adoption across both ecosystems?
+
+5. **Registry Support**: How should registries that index both MCP servers and A2A agents handle discovery? Should they require `/.well-known/ai-cards.json` or also support individual protocol discovery endpoints? Ideally they support multiple discovery approaches and MAY optionally support more advanced protocols like e.g. ORD.
+
+6. **Registry Data Model**: For publishing to registries, one protocol should only have one metadata format. But a registry may need to additional metadata (calculated or server-side information) and context. This concern should be separated, so a registry API / data format could be a superset of MCP Cards or A2A Agent Cards. Clarify that registries are optional and can have their own superset model.
+
+7. **Access Control**: Support protection of metadata files? If metadata is protected, should the discovery document give hints how to access it (access strategy)?
+
+8. **Dynamic Metadata**: Can the discovery document or the attached metadata files be dynamic? For example, metadata can be tenant-specific in products that feature heavy customization.
+
+## Alternatives Considered
+
+### Unified Card Model
+
+Creating a single card format that both MCP and A2A adopt. Proposal is to reject this due to the coordination overhead and risk of creating yet another standard.
+
+### Protocol-Specific Discovery (Status Quo)
+Having each protocol define its own discovery mechanism:
+- MCP: `/.well-known/mcp/server-card.json` ([SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127))
+- A2A: `/.well-known/a2a/agent-card.json` (proposed)
+
+**Advantages:**
+- Each protocol has full control
+- No cross-protocol coordination needed
+- Simpler for single-protocol deployments
+
+**Disadvantages:**
+- Clients must probe multiple endpoints to discover all capabilities
+- Registries must crawl multiple endpoints per domain
+- No standard way to discover what protocols a domain supports
+- N+1 HTTP requests where N is the number of protocols
+
+**Integration Path:**
+This SEP could be implemented **alongside** protocol-specific endpoints:
+1. `/.well-known/ai-cards.json` serves as a directory
+2. `metadata.url` points to protocol-specific endpoints like `/.well-known/mcp/server-card.json`
+3. Single-protocol deployments can skip the directory and only implement their protocol-specific endpoint
+4. Multi-protocol deployments and registries benefit from the unified discovery
+
+This allows gradual adoption without breaking existing protocol-specific discovery mechanisms.
+
+### DNS-Based Discovery
+
+Using DNS TXT records for discovery (similar to DKIM or SPF). 
+- Only works at domain level, not for path-based or port-based deployments
+- Requires DNS infrastructure control
+- More complex to implement and query
+- Less accessible for web-based clients
+
+This approach could be rejected or be allowed as an alternative to the .well-known URI approach in the future.
+
+## Prior Art
+
+### MCP SEP-2127: MCP Server Cards - HTTP Server Discovery
+
+- **Issue**: [#1649](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649)
+- **Pull Request**: [#2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127)
+- **Proposed Endpoint**: `/.well-known/mcp/server-card.json` (single server assumption)
+
+SEP-2127 proposes a comprehensive MCP Server Card format including:
+- Server identification and versioning
+- Transport configuration (streamable-http, stdio, SSE)
+- Capabilities (tools, prompts, resources)
+- Authentication requirements
+- Static or dynamic primitive declarations
+- Protocol version information
+
+**Relationship to this SEP:**
+- SEP-2127's card format provides excellent detail on **what metadata to include**
+- This SEP addresses **how to discover** that metadata, especially when multiple servers/agents exist
+- The MCP Server Card format should evolve from MCP Registry's `server.json`, enhanced with SEP-2127's additions
+- Discovery should use this SEP's shared `/.well-known/ai-cards.json` mechanism rather than protocol-specific endpoints
+
+### MCP Registry server.json Format
+- **Repository**: [modelcontextprotocol/registry](https://github.com/modelcontextprotocol/registry)
+- **JSON Schema**: [2025-12-11.json](https://github.com/modelcontextprotocol/registry/blob/main/internal/validators/schemas/2025-12-11.json)
+- **Current use**: Registry entries for MCP servers
+- **Limitations**: Missing tools, prompts, resources definitions
+
+**Relationship to this SEP:**
+- Provides the foundation for MCP Server Card format
+- Needs enhancement with primitives (tools, prompts, resources, etc.) as proposed in SEP-2127
+- Would be discoverable via `metadata.url` in this proposal
+
+### A2A: `/.well-known/agent.json`
+
+- **Issue**: [IANA Well-Known URI Registration](https://github.com/protocol-registries/well-known-uris/issues/66)
+- **Specification**: [A2A Protocol](https://a2a-protocol.org/latest/specification/)
+- **Endpoint**: `/.well-known/agent.json` (singular - one agent assumption)
+- **Status**: Registered/In progress with IANA
+
+A2A has defined a well-known URI for agent discovery with comprehensive A2A Agent Cards including:
+- Agent identification and metadata
+- Capabilities and supported operations
+- Authentication and authorization requirements
+- Endpoint information
+
+**Relationship to this SEP:**
+- A2A's agent card format is well-defined and should remain A2A-owned
+- The `/.well-known/agent.json` endpoint assumes one agent per host (singular filename)
+- This SEP enables discovery of **multiple agents** on a single host
+- The `metadata.url` in this proposal can point to individual A2A Agent Card files
+
+### RFC 9727: `/.well-known/api-catalog`
+
+- **RFC**: [RFC 9727](https://datatracker.ietf.org/doc/rfc9727/)
+- **Endpoint**: `/.well-known/api-catalog`
+- **Format**: Linkset (application/linkset+json) per RFC 9264
+- **Scope**: Generic API discovery across all API types
+- **Status**: Published IETF Standards Track (June 2025)
+
+RFC 9727 defines a well-known URI for discovering **any** APIs published by a domain, using a Linkset format that provides:
+- Links to API endpoints (`item` relation)
+- Links to API descriptions (OpenAPI specs via `service-desc`)
+- Links to documentation (`service-doc`)
+- Metadata about APIs (`service-meta`)
+- Support for nested catalogs
+
+**Relationship to this SEP:**
+
+**Similarities:**
+- Both use `.well-known` URIs for discovery
+- Both support multiple services per host (RFC 9727 via Linkset arrays)
+- Both enable machine-readable discovery
+
+**Key Differences:**
+
+1. **Scope**: 
+   - RFC 9727: **Generic API catalog** - works for REST APIs, GraphQL, SOAP, or any API type
+   - This SEP: **AI-native protocol discovery** - specifically for MCP servers and A2A agents
+
+2. **Protocol Awareness**:
+   - RFC 9727: **Protocol-agnostic** - doesn't specify what protocol the APIs use (only mediaType like `application/json`)
+   - This SEP: **Protocol-specific** - explicitly identifies `protocolType` (mcp, a2a) and links to protocol-specific metadata
+
+3. **Metadata Structure**:
+   - RFC 9727: Links to generic metadata (OpenAPI specs, docs) using standard link relations
+   - This SEP: Points to protocol-specific card formats (MCP Server Cards, A2A Agent Cards) that include protocol-specific capabilities
+
+### Open Resource Discovery: `.well-known/open-resource-discovery`
+
+- **Specification**: [Open Resource Discovery (ORD)](https://open-resource-discovery.org/spec-v1)
+- **Governance**: Linux Foundation
+- **Endpoint**: `/.well-known/open-resource-discovery`
+- **Scope**: Enterprise-grade discovery of APIs, Events, Data Products, Domain Objects, Taxonomy and more
+- **Complexity**: Comprehensive, feature-rich standard
+ 
+ORD is an **enterprise-grade** discovery protocol that provides comprehensive resource discovery capabilities far beyond simple API discovery:
+
+**ORD Capabilities:**
+- **API Resources**: REST APIs, MCP, A2A, OData, GraphQL, etc.
+- **Event Resources**: Cloud Events, AsyncAPI, etc.
+- **Data Products**: Data sets, data models, Delta Sharing, etc.
+- **Domain Objects**: Business entities and domain models
+- **Static vs Dynamic Perspectives**: Distinguishes between system-type-level (static) and system-instance-level (tenant-specific, runtime) metadata
+- **Aggregation**: Complex aggregation capabilities for multi-system landscapes
+- **Access Strategies**: Multiple authentication and authorization patterns
+
+**Relationship to this SEP:**
+
+**ORD can handle AI protocol discovery today:**
+- ORD's flexible resource model already represents MCP servers and A2A agents as "API Resources". Agents can be described as dedicated entity to describe and govern the non-technical, product qualities.
+- ORD's static/dynamic perspectives can distinguish between server/agent capabilities and tenant-specific configurations
+- ORD provides a shared high-level meta-model across API protocols and even resource types
+- ORD's taxonomy can categorize AI resources
+
+**Why this SEP is still valuable:**
+
+1. **Simplicity vs Complexity**:
+   - ORD: Enterprise-grade with extensive features (perspectives, aggregation, taxonomy, access strategies)
+   - This SEP: **Simple, focused** - just protocol type, endpoints, and metadata URL
+   - AI Card implementers want **minimal overhead**, not enterprise complexity
+
+2. **Scope Focus**:
+   - ORD: **Broad** - APIs, events, data products, domain objects, business taxonomy
+   - This SEP: **Narrow** - AI protocols only (MCP, A2A, future AI protocols)
+   - AI registries don't need data products, domain objects, or business taxonomy
+
+3. **Adoption Barrier**:
+   - ORD: Requires understanding extensive specification, implementing complex data models
+   - This SEP: Small JSON Schema contract, 3 required fields
+   - Lower barrier → faster ecosystem adoption
+
+4. **Protocol Specificity**:
+   - ORD: Generic resource discovery (protocol-agnostic)
+   - This SEP: **Protocol-aware** - explicitly identifies MCP vs A2A with protocol-specific card links
+   - Makes it trivial for AI clients to distinguish tools from agents
+
+5. **Target Audience**:
+   - ORD: **Enterprise IT** - managing complex multi-system landscapes holistically with governance requirements
+   - This SEP: **AI developers** - building and discovering AI agents and tools quickly
+
+**Could they coexist?**
+
+Yes, they target different audiences:
+- **Enterprise environments** with ORD: Could list AI Cards as one category of API resources within ORD
+- **AI-focused environments**: Implement lightweight `/.well-known/ai-cards.json` without ORD overhead
+- **Hybrid**: Implement both - ORD for comprehensive enterprise discovery, AI Cards for simple AI-specific discovery
+
+## Related Work
+
+- [RFC 8615: Well-Known Uniform Resource Identifiers (URIs)](https://www.rfc-editor.org/rfc/rfc8615.html) - Foundation for .well-known URIs
+- [RFC 9727: api-catalog](https://datatracker.ietf.org/doc/rfc9727/) - Generic API discovery (see Prior Art for detailed comparison)
+- [Open Resource Discovery (ORD)](https://open-resource-discovery.org/spec-v1) - Enterprise-grade resource discovery (see Prior Art for detailed comparison)
+- [RFC 9264: Linkset](https://www.rfc-editor.org/rfc/rfc9264.html) - Link set format used by api-catalog
+- [OAuth 2.0 Authorization Server Metadata (RFC 8414)](https://www.rfc-editor.org/rfc/rfc8414.html) - Similar discovery pattern for OAuth servers
+- [OpenID Connect Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html) - Well-known endpoint for identity providers

--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -12,8 +12,8 @@ Created: 2026-01-24
 This SEP proposes a standardized discovery mechanism for AI native protocols and their metadata through a [.well-known URI](https://www.rfc-editor.org/rfc/rfc8615) endpoint (`/.well-known/ai-cards.json`). This solves the discovery problem that both [MCP](https://modelcontextprotocol.io) (Model Context Protocol) and [A2A](https://a2a-protocol.org) (Agent-to-Agent) protocols face, eliminating the need for each protocol to define its own discovery mechanism independently.
 
 The proposal recognizes that:
-- **A2A** has defined [`/.well-known/agent.json`](https://github.com/protocol-registries/well-known-uris/issues/66) for discovery, but assumes **one agent per host**
-- **MCP Server Cards** need to evolve from the existing MCP Registry `server.json` format to include tools, prompts, and resources, proposed as [MCP Server Cards (SEP-2127)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127), with discovery at `/.well-known/mcp/server-card.json` assuming **one server per host**
+- **A2A** has defined [`/.well-known/agent.json`](https://github.com/protocol-registries/well-known-uris/issues/66) for discovery, but has a **single-service assumption** (one agent per host)
+- **MCP Server Cards** need to evolve from the existing MCP Registry `server.json` format to include tools, prompts, and resources, proposed as [MCP Server Cards (SEP-2127)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127), with discovery at `/.well-known/mcp/server-card.json` also having a **single-service assumption** (one server per host)
 - Both protocols face the **same limitation**: the single-service assumption doesn't fit real-world multi-service deployments
 - **Discovery** is a shared concern that benefits from a unified, multi-service approach
 - **Future-proofing**: The discovery mechanism is designed to support future AI protocols, versions and their metadata formats
@@ -39,9 +39,9 @@ In reality, a single host can and should be able to expose:
 
 ### The Single-Service Assumption Problem
 
-**Both A2A and MCP discovery mechanisms share the same critical limitation:**
-- A2A: `/.well-known/agent.json` (singular) → assumes one agent
-- MCP: `/.well-known/mcp/server-card.json` (singular) → assumes one server
+**Both A2A and MCP discovery mechanisms share the same critical limitation: the single-service assumption.**
+- A2A: `/.well-known/agent.json` (singular) → single-service assumption (one agent per host)
+- MCP: `/.well-known/mcp/server-card.json` (singular) → single-service assumption (one server per host)
 
 This breaks down in real-world scenarios:
 - A company may host multiple specialized agents (sales, support, analytics)
@@ -79,10 +79,11 @@ By appending `.json` it is easier to host this and the linked metadata files on 
 
 The discovery document MUST be a JSON object following the [ai-card-v0.schema.json](./0000-ai-card-discovery.schema.json) schema.
 
-```json
+```jsonc
 {
   "$schema": "https://ai-card.org/schemas/ai-card-v0.schema.json",
   "protocols": [
+    // A2A agent example
     {
       "type": "a2a",
       "endpoints": [{"url": "https://example.com/a2a-endpoint"}],
@@ -91,6 +92,7 @@ The discovery document MUST be a JSON object following the [ai-card-v0.schema.js
         "url": "https://example.com/.well-known/PetAgent.json"
       }
     },
+    // First MCP server - petstore
     {
       "type": "mcp",
       "endpoints": [{"url": "https://example.com/mcp-endpoint"}],
@@ -99,6 +101,7 @@ The discovery document MUST be a JSON object following the [ai-card-v0.schema.js
         "url": "https://example.com/.well-known/petstore.mcp.json"
       }
     },
+    // Second MCP server - inventory (demonstrates multi-service capability)
     {
       "type": "mcp",
       "endpoints": [{"url": "https://example.com/mcp-endpoint-inventory"}],
@@ -134,22 +137,42 @@ Relative URLs are resolved **relative to the location of the discovery document*
 - `/api/mcp` → resolves to `/api/mcp` (relative to host root)
 - `/metadata/petstore.mcp.json` → resolves to `/metadata/petstore.mcp.json`
 
+#### URL Resolution Examples
+
 For a discovery document served at `https://example.com/.well-known/ai-cards.json`:
-- `./mcp` resolves to `https://example.com/.well-known/mcp`
-- `./petstore.mcp.json` resolves to `https://example.com/.well-known/petstore.mcp.json`
+
+| URL Type | Example in Document | Resolves To |
+|----------|---------------------|-------------|
+| Absolute | `https://api.example.com/mcp` | `https://api.example.com/mcp` |
+| Path-relative | `./petstore.mcp.json` | `https://example.com/.well-known/petstore.mcp.json` |
+| Path-relative | `../metadata/server.json` | `https://example.com/metadata/server.json` |
+| Absolute-path | `/api/mcp` | `https://example.com/api/mcp` |
 
 **Recommendation**: Use relative URLs when metadata and endpoints are co-located with the discovery document. Use absolute URLs when pointing to external services or different domains.
 
 ### Metadata Files
 
-The content and structure of metadata files referenced by `metadata.url` are **owned and defined by their respective protocol communities**:
+Each protocol community maintains **full ownership** of their metadata format. This SEP only defines the discovery mechanism that points to these files.
 
-- **MCP Server Cards**: Should evolve from the existing [MCP Registry `server.json` format](https://github.com/modelcontextprotocol/registry) ([JSON Schema](https://github.com/modelcontextprotocol/registry/blob/main/internal/validators/schemas/2025-12-11.json)), enhanced with tools, prompts, and resources as proposed in [SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127). The MCP community maintains full control over this schema.
+#### Protocol-Specific Metadata Formats
 
-- **A2A Agent Cards**: Already defined by the A2A specification. The A2A community maintains full control over this schema.
+- **MCP Server Cards** (Defined by MCP community):
+  - Should evolve from the existing [MCP Registry `server.json` format](https://github.com/modelcontextprotocol/registry) ([JSON Schema](https://github.com/modelcontextprotocol/registry/blob/main/internal/validators/schemas/2025-12-11.json))
+  - Enhanced with tools, prompts, and resources as proposed in [SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127)
+  - Full schema control remains with the MCP community
 
-This SEP **intentionally does not mandate** any particular structure for these metadata files. It only defines the discovery mechanism that points to them.
-The scope could be increased to also indicating the version(s) of the protocols and metadata files that are provided.
+- **A2A Agent Cards** (Defined by A2A specification):
+  - Already well-defined by the A2A specification
+  - Full schema control remains with the A2A community
+
+#### Scope of This SEP
+
+This SEP **intentionally does not mandate** any particular structure for metadata files. It only standardizes:
+1. How to **discover** multiple services on a single host
+2. How to **identify** protocol types (`type` field)
+3. How to **locate** metadata files (`metadata.url` field)
+
+The scope could be expanded in the future to indicate version(s) of protocols and metadata formats (see Open Questions).
 
 ## Rationale
 
@@ -172,11 +195,11 @@ By keeping card definitions protocol-specific, each group maintains autonomy whi
 ### Minimal Coordination Surface
 
 This proposal minimizes the coordination surface to just three pieces of information:
-1. Protocol type identifier (`protocolType`)
-2. Where to connect (`endpoints`)
-3. Where to find metadata (`metadata`)
+1. Protocol type identifier (the `type` field)
+2. Where to connect (the `endpoints` array)
+3. Where to find metadata (the `metadata` object with `type` and `url`)
 
-This allows protocols to evolve their metadata formats independently.
+This allows protocols to evolve their metadata formats independently while sharing a common discovery mechanism.
 
 ### Relationship to Existing Discovery Mechanisms
 
@@ -227,21 +250,92 @@ This is a new feature and does not introduce backward compatibility concerns. Se
 
 ## Open Questions
 
-1. **Versioning**: Should the protocol `type` field include version information (e.g., "mcp/v1", "a2a/v1")? Or should versioning be handled in the protocol-specific metadata files?
+### 1. Protocol Versioning Strategy
 
-2. **Metadata Definition Versioning**: Should there be a mechanism to indicate which version of the metadata definition format is being used?
+**Question**: Should the protocol `type` field include version information (e.g., `"mcp/v1"`, `"a2a/v2"`)?
 
-3. **Multiple Versions**: If a service supports multiple versions of a protocol, should they be separate entries in `protocols` (e.g. "a2a-v1", "a2a-v2") and metadata types ("a2a-agent-card-v1", "a2a-agent-card-v2") or should version information be only available by actually fetching the metadata files / connecting to the endpoints?
+**Options**:
+- **A)** Include in `type`: `"mcp/v1"`, `"a2a/v2"`
+- **B)** Separate `version` field: `{"type": "mcp", "version": "1.0"}`
+- **C)** Only in metadata files: Extract from `$schema` or dedicated version field
 
-4. **Coordination with MCP SEP-2127**: Should this SEP be proposed to the MCP community, or should it be maintained as a separate cross-protocol specification? If the latter, how do we ensure adoption across both ecosystems?
+**Trade-offs**:
+- Option A enables protocol version filtering without fetching metadata
+- Option C keeps discovery simpler but requires metadata fetch to determine version
+- Option B provides structured versioning but adds a required field
 
-5. **Registry Support**: How should registries that index both MCP servers and A2A agents handle discovery? Should they require `/.well-known/ai-cards.json` or also support individual protocol discovery endpoints? Ideally they support multiple discovery approaches and MAY optionally support more advanced protocols like e.g. ORD.
+**Recommendation needed**: How important is version-based filtering at the discovery layer?
 
-6. **Registry Data Model**: For publishing to registries, one protocol should only have one metadata format. But a registry may need to additional metadata (calculated or server-side information) and context. This concern should be separated, so a registry API / data format could be a superset of MCP Cards or A2A Agent Cards. Clarify that registries are optional and can have their own superset model.
+### 2. Metadata Format Versioning
 
-7. **Access Control**: Support protection of metadata files? If metadata is protected, should the discovery document give hints how to access it (access strategy)?
+**Question**: How should clients determine which version of a metadata format (e.g., MCP Server Card schema) is being used?
 
-8. **Dynamic Metadata**: Can the discovery document or the attached metadata files be dynamic? For example, metadata can be tenant-specific in products that feature heavy customization.
+**Options**:
+- **A)** Add `metadata.schemaVersion` field in discovery document
+- **B)** Rely on `$schema` field within the metadata file itself
+- **C)** Include version in `metadata.type`: `"mcp-server-card-v1"`
+
+**Impact**: Affects whether clients can validate compatibility before fetching metadata files.
+
+### 3. Supporting Multiple Protocol Versions
+
+**Question**: If a service supports multiple versions of a protocol (e.g., MCP v1 and v2), how should this be represented?
+
+**Options**:
+- **A)** Separate entries in `protocols` array (one per version)
+- **B)** Single entry with version negotiation at connection time
+- **C)** List supported versions within the metadata file
+
+**Example scenario**: A server supports both legacy clients (MCP v1) and new clients (MCP v2).
+
+### 4. Governance and Coordination
+
+**Question**: Should this SEP be:
+- **A)** Proposed to MCP community (as MCP SEP) with A2A adoption?
+- **B)** Maintained as separate cross-protocol specification?
+- **C)** Submitted to IETF/W3C as a broader standard?
+
+**Adoption strategy**: How do we ensure both MCP and A2A ecosystems adopt this approach?
+
+### 5. Registry Discovery Requirements
+
+**Question**: Should registries that index multiple protocols:
+- **A)** **Require** `/.well-known/ai-cards.json` as primary discovery
+- **B)** **Support** both AI Cards and protocol-specific endpoints (e.g., `/.well-known/agent.json`)
+- **C)** **Also support** advanced protocols like ORD for enterprise environments
+
+**Recommendation**: Option B provides maximum compatibility during transition period.
+
+### 6. Registry Data Model Separation
+
+**Question**: How should registry-specific metadata (ratings, download counts, verification status) be handled?
+
+**Proposal**: Clarify that:
+- **Service metadata** (MCP Server Cards, A2A Agent Cards) describes the service itself
+- **Registry metadata** (ratings, stats) is a registry concern, potentially a superset model
+- Registries are **optional** and can define their own API/data models
+
+### 7. Access Control for Metadata
+
+**Question**: Should the discovery document indicate when metadata requires authentication?
+
+**Options**:
+- **A)** Add `metadata.accessStrategy` field (e.g., `"public"`, `"oauth2"`, `"api-key"`)
+- **B)** Clients discover through HTTP 401/403 responses
+- **C)** No indication - assume public discovery, protected metadata requires docs
+
+### 8. Dynamic and Tenant-Specific Metadata
+
+**Question**: How should dynamic or tenant-specific metadata be handled?
+
+**Use case**: Multi-tenant SaaS where each tenant has different available tools/capabilities.
+
+**Options**:
+- **A)** Allow dynamic generation of discovery document and metadata files
+- **B)** Use query parameters: `/.well-known/ai-cards.json?tenant=acme`
+- **C)** Document that discovery is static; dynamic capabilities in metadata files
+
+**Security consideration**: Tenant isolation and information disclosure.
 
 ## Alternatives Considered
 
@@ -285,6 +379,15 @@ Using DNS TXT records for discovery (similar to DKIM or SPF).
 This approach could be rejected or be allowed as an alternative to the .well-known URI approach in the future.
 
 ## Prior Art
+
+### Summary of Related Standards
+
+| Standard | Endpoint | Scope | Single/Multi-Service | Relationship to This SEP |
+|----------|----------|-------|----------------------|-------------------------|
+| **A2A Agent Discovery** | `/.well-known/agent.json` | A2A agents only | Single-service | This SEP enables multi-agent discovery |
+| **MCP SEP-2127** | `/.well-known/mcp/server-card.json` | MCP servers only | Single-service | This SEP enables multi-server discovery |
+| **RFC 9727 (API Catalog)** | `/.well-known/api-catalog` | All API types | Multi-service | Generic, not AI-protocol-aware |
+| **ORD** | `/.well-known/open-resource-discovery` | APIs, Events, Data Products | Multi-service | Enterprise-grade, broader scope than AI |
 
 ### MCP SEP-2127: MCP Server Cards - HTTP Server Discovery
 

--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -348,11 +348,20 @@ ORD **can** handle AI protocol discovery today, but targets a different audience
 - **AI-focused environments**: Use lightweight `/.well-known/ai-cards.json`
 - **Hybrid deployments**: Implement both as needed
 
-## Related Work
+## Links
 
-- [RFC 8615: Well-Known Uniform Resource Identifiers (URIs)](https://www.rfc-editor.org/rfc/rfc8615.html) - Foundation for .well-known URIs
-- [RFC 9727: api-catalog](https://datatracker.ietf.org/doc/rfc9727/) - Generic API discovery (see Prior Art for detailed comparison)
-- [Open Resource Discovery (ORD)](https://open-resource-discovery.org/spec-v1) - Enterprise-grade resource discovery (see Prior Art for detailed comparison)
-- [RFC 9264: Linkset](https://www.rfc-editor.org/rfc/rfc9264.html) - Link set format used by api-catalog
-- [OAuth 2.0 Authorization Server Metadata (RFC 8414)](https://www.rfc-editor.org/rfc/rfc8414.html) - Similar discovery pattern for OAuth servers
-- [OpenID Connect Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html) - Well-known endpoint for identity providers
+- [Model Context Protocol (MCP)](https://modelcontextprotocol.io) - Protocol for connecting AI assistants to data sources and tools
+  - [MCP SEP-2127: Server Cards](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127) - Proposed MCP Server Card format
+  - [MCP Registry](https://github.com/modelcontextprotocol/registry) - Existing registry format
+- [Agent-to-Agent Protocol (A2A)](https://a2a-protocol.org) - Protocol for agent-to-agent communication
+  - [A2A Specification](https://a2a-protocol.org/latest/specification/)
+  - [A2A Well-Known URI Registration](https://github.com/protocol-registries/well-known-uris/issues/66)
+
+- Discovery protocols
+  - [RFC 9727: api-catalog](https://datatracker.ietf.org/doc/rfc9727/) - Generic API discovery (see Prior Art for detailed comparison)
+  - [Open Resource Discovery (ORD)](https://open-resource-discovery.org/spec-v1) - Enterprise-grade resource discovery (see Prior Art for detailed comparison)
+  - [Entity Discovery Protocol (EDP)](https://github.com/edp-protocol/entity-discovery-protocol) - Protocol for discovering business entities
+
+- Foundational standards
+  - [RFC 8615: Well-Known Uniform Resource Identifiers (URIs)](https://www.rfc-editor.org/rfc/rfc8615.html) - Foundation for .well-known URIs
+  - [RFC 3986: Uniform Resource Identifier (URI): Generic Syntax](https://www.rfc-editor.org/rfc/rfc3986) - URL resolution rules used in this specification

--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -178,9 +178,9 @@ This is a new feature and does not introduce backward compatibility concerns. Se
 
 ## Open Questions
 
-### 1. Protocol Versioning Strategy
+### 1. Protocol and Metadata Format Versioning Strategy
 
-**Question**: If a service supports multiple versions of a protocol (e.g., MCP v1 and v2), how should this be represented?
+**Question**: If a service supports multiple versions of a protocol (e.g., MCP v1 and v2) and metadata formats (e.g. Agent Card v1 and v2), how should this be represented?
 Should the protocol `type` field include version information (e.g., `"mcp/v1"`, `"a2a/v2"`)?
 
 **Options**:
@@ -196,6 +196,7 @@ Should the protocol `type` field include version information (e.g., `"mcp/v1"`, 
 ### 2. Access Control for Metadata
 
 **Question**: Should the discovery document indicate when metadata requires authentication?
+Do we have to support public and internal metadata (internal could be richer)?
 
 **Options**:
 - **A)** Add `metadata.accessStrategy` field (e.g., `"public"`, `"oauth2"`, `"api-key"`)
@@ -317,25 +318,25 @@ A2A has defined [`/.well-known/agent.json`](https://a2a-protocol.org/latest/spec
 | Aspect | RFC 9727 | This SEP |
 |--------|----------|----------|
 | **Scope** | Generic APIs (REST, GraphQL, SOAP, etc.) | AI-native protocols (MCP, A2A) |
-| **Protocol Awareness** | Protocol-agnostic | Protocol-specific (`type: mcp` vs `type: a2a`) |
+| **Protocol Awareness** | Protocol-agnostic, undefined | Protocol-specific (`type: mcp` vs `type: a2a`) |
 | **Metadata** | Links to OpenAPI specs, generic docs | Links to AI-specific card formats (MCP Server Cards, A2A Agent Cards) |
 
-**Relationship**: RFC 9727 is too generic for AI protocol discovery; this SEP provides AI-specific protocol identification and metadata.
+**Relationship**: RFC 9727 is too generic for AI protocol discovery. It does neither state which protocol nor which metadata format is provided, just a generic MIME type. This SEP provides AI-specific protocol identification and metadata.
 
 ### Open Resource Discovery: `.well-known/open-resource-discovery`
 
-[ORD](https://open-resource-discovery.org/spec-v1) (Linux Foundation) is an enterprise-grade discovery protocol for APIs, events, data products, domain objects, and taxonomy.
+[ORD](https://open-resource-discovery.org/spec-v1) (Linux Foundation) is an enterprise-grade discovery protocol for APIs, events, data products, domain objects, (business) taxonomy and more.
 
 **ORD capabilities include:**
 - Multiple resource types and protocols supported (APIs, events, data products, agents, lightweight system landscape model)
 - Includes defining and linking of taxonomies and business-concepts (vendors, products, domain / business objects) 
-- Static vs dynamic perspectives (system-type vs tenant-specific)
-- Aggregation across multi-system landscapes
-- Access strategies and governance
+- Static vs dynamic perspectives (design-time vs tenant-specific run-time metadata)
+- Access strategies and governance aspects
 
 **Relationship to this SEP:**
 
-ORD **can** handle AI protocol discovery today, but targets a different audience:
+ORD **can** handle AI protocol discovery today, but due to enterprise requirements it is quite complex. 
+This proposal assumes that for the AI ecosystem a simpler approach is desired and more realistic.
 
 | Aspect | ORD | This SEP |
 |--------|-----|----------|

--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -22,50 +22,32 @@ By providing a protocol-agnostic discovery layer, this SEP enables a single host
 
 ## Motivation
 
-### The Current Landscape
+### The Problem: Single-Service Assumption
 
-**A2A** has defined [`/.well-known/agent.json`](https://github.com/protocol-registries/well-known-uris/issues/66) for agent discovery, with A2A Agent Cards providing comprehensive metadata about agents. However, the endpoint assumes **one agent per host** and the discovery mechanism is exclusive to A2A.
+Both **A2A** and **MCP** are defining protocol-specific discovery mechanisms:
+- **A2A**: [`/.well-known/agent.json`](https://github.com/protocol-registries/well-known-uris/issues/66) 
+- **MCP**: `/.well-known/mcp/server-card.json` ([SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127))
 
-**MCP** has proposed [SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127) defining `/.well-known/mcp/server-card.json` for server discovery, with comprehensive server metadata. However, it also assumes **one MCP server per host** and the discovery mechanism is exclusive to MCP.
+Both share a critical **single-service assumption**: one agent or server per host.
 
-Both protocols also have existing metadata formats:
-- **A2A Agent Cards**: Already well-defined for agent metadata
-- **MCP Registry `server.json`**: Exists for registry entries but is incomplete (missing tools, prompts, resources)
+**This breaks down in real-world scenarios:**
+- A host needs to expose multiple specialized services (e.g., petstore + inventory MCP servers, or sales + support A2A agents)
+- A platform provides both MCP servers and A2A agents
+- Registries must discover all available services, not just a "primary" one
 
-In reality, a single host can and should be able to expose:
-- Multiple MCP servers (e.g., a petstore server and an inventory server)
-- Multiple A2A agents (e.g., a customer service agent and a sales agent)
-- A mix of both protocols
+### The Problem: Discovery Fragmentation
 
-### The Single-Service Assumption Problem
-
-**Both A2A and MCP discovery mechanisms share the same critical limitation: the single-service assumption.**
-- A2A: `/.well-known/agent.json` (singular) → single-service assumption (one agent per host)
-- MCP: `/.well-known/mcp/server-card.json` (singular) → single-service assumption (one server per host)
-
-This breaks down in real-world scenarios:
-- A company may host multiple specialized agents (sales, support, analytics)
-- A domain may host multiple distinct MCP servers (petstore, inventory, analytics)
-- A platform may provide both MCP servers and A2A agents
-- Registries need to discover all available services, not just the "primary" one
-
-### The Multi-Protocol Discovery Problem
-
-Beyond the single-service limitation, having separate protocol-specific discovery endpoints creates additional friction:
-- **Clients must probe multiple endpoints**: Try `/.well-known/agent.json`, then `/.well-known/mcp/server-card.json`, then future protocols
-- **Registries must implement multiple discovery protocols**: Each protocol adds complexity
-- **No standard way to discover what protocols a domain supports**: Clients must guess and try each one
-- **N+1 HTTP requests**: One request per protocol, with failures for unsupported ones
+Having separate protocol-specific endpoints creates additional friction:
+- **Multiple probes required**: Clients must try `/.well-known/agent.json`, then `/.well-known/mcp/server-card.json`, then future protocols
+- **N+1 HTTP requests**: One per protocol, with many failures for unsupported protocols
+- **No capability indication**: No standard way to discover what AI protocols a domain supports
 
 ### This Proposal
 
-This SEP addresses these challenges by:
-
-1. **Solving discovery once**: Provides a single, protocol-agnostic discovery mechanism
-2. **Avoiding model proliferation**: Each protocol maintains its own card definitions (A2A Agent Cards, MCP Server Cards)
-3. **Supporting multiple servers/agents**: Explicitly designed for hosts exposing multiple services
-4. **Reducing coordination overhead**: Protocols only need to agree on discovery, not on card formats
-5. **Simplifying the ecosystem**: One endpoint to discover all AI capabilities on a domain
+This SEP provides a **single, protocol-agnostic discovery endpoint** (`/.well-known/ai-cards.json`) that:
+1. Enables **multi-service discovery** (multiple MCP servers and/or A2A agents per host)
+2. Enables **multi-protocol discovery** (single request reveals all AI capabilities)
+3. Allows each protocol to **maintain full ownership** of their metadata formats
 
 ## Specification
 
@@ -176,59 +158,35 @@ The scope could be expanded in the future to indicate version(s) of protocols an
 
 ## Rationale
 
-### Why a Well-Known URI?
+### Why Not a Shared Metadata Model?
 
-The `.well-known` URI scheme ([RFC 8615](https://www.rfc-editor.org/rfc/rfc8615)) is a well-established standard for service discovery, making it a natural fit for AI Card discovery. It allows clients to probe a service for capabilities without prior configuration.
-Compared to a centralized registry push model, this approach provides local self-description and a decentralized discovery mechanism.
+Rather than creating a unified card format for MCP and A2A, this SEP keeps card definitions protocol-specific to avoid:
+- Ongoing coordination overhead between protocol groups
+- Potential compromises that don't serve either protocol well
+- Slower evolution requiring multi-party consensus
 
-### Why Not a Shared Model?
+### Design Principles
 
-Creating a shared model between MCP and A2A would require:
-
-1. Ongoing coordination between protocol groups
-2. Libraries to support an additional standard
-3. Potential compromises that don't serve either protocol well
-4. Slower evolution as changes require multi-party consensus
-
-By keeping card definitions protocol-specific, each group maintains autonomy while still enabling discovery.
-
-### Minimal Coordination Surface
-
-This proposal minimizes the coordination surface to just three pieces of information:
+**Minimal Coordination Surface**: This SEP minimizes cross-protocol coordination to just three pieces of information:
 1. Protocol type identifier (the `type` field)
-2. Where to connect (the `endpoints` array)
-3. Where to find metadata (the `metadata` object with `type` and `url`)
+2. Connection endpoints (the `endpoints` array)  
+3. Metadata location (the `metadata` object with `type` and `url`)
 
-This allows protocols to evolve their metadata formats independently while sharing a common discovery mechanism.
+Each protocol maintains **full ownership** of their card formats and can evolve independently.
 
-### Relationship to Existing Discovery Mechanisms
+**Standard Discovery Pattern**: Uses the well-established `.well-known` URI scheme ([RFC 8615](https://www.rfc-editor.org/rfc/rfc8615)) for decentralized, client-initiated discovery without requiring centralized registries.
 
-Both MCP and A2A have defined protocol-specific discovery endpoints:
+### Integration with Existing Mechanisms
 
-**A2A: `/.well-known/agent.json`**
-- **Status**: [Registered with IANA](https://github.com/protocol-registries/well-known-uris/issues/66)
-- **Specification**: [A2A Protocol](https://a2a-protocol.org/latest/specification/)
-- **Limitation**: Assumes one agent per host (singular `agent.json`)
+This SEP **coexists** with protocol-specific discovery endpoints:
+- A2A's `/.well-known/agent.json`
+- MCP's proposed `/.well-known/mcp/server-card.json` (SEP-2127)
 
-**MCP: `/.well-known/mcp/server-card.json`** 
-- **Status**: [Proposed in SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127)
-- **Limitation**: Assumes one MCP server per host
-
-**This SEP addresses the shared limitations:**
-
-1. **Supporting multiple services per host**: The `protocols` array can list many MCP servers and/or A2A agents
-2. **Enabling multi-protocol discovery**: A single request reveals all available AI services
-3. **Avoiding discovery fragmentation**: One shared endpoint instead of N protocol-specific endpoints
-4. **Backward compatibility**: Can coexist with protocol-specific endpoints (see Integration Path in Alternatives)
-
-### MCP Server Card Format Evolution
-
-This SEP **does not define** the MCP Server Card format itself. Instead MCP Server Cards should evolve to:
-- Ideally merge with the existing MCP Registry `server.json` format, by adding the missing elements. We should avoid having two different formats to describe an MCP server, depending on where/how we publish. MCP Server Cards could be a convention on top of the existing format, describing which elements are required and optional.
-- **Remain MCP-owned**: The MCP community maintains full control over the MCP Server Card schema
-- **Be discoverable via** this shared `/.well-known/ai-cards.json` mechanism
-
-Similarly, **A2A Agent Cards** (already defined) would be discoverable through the same mechanism, allowing both protocols to evolve independently while sharing a common discovery layer.
+**How it works:**
+- The `protocols` array enables multi-service discovery
+- `metadata.url` can point to protocol-specific card files
+- Single-protocol deployments can use protocol-specific endpoints
+- Multi-protocol deployments and registries benefit from unified discovery at `/.well-known/ai-cards.json`
 
 ## Backward Compatibility
 
@@ -240,13 +198,10 @@ This is a new feature and does not introduce backward compatibility concerns. Se
 
 ## Security Implications
 
-1. **HTTPS Required**: Implementations SHOULD require HTTPS for all URLs in the discovery document to prevent man-in-the-middle attacks
-
-2. **URL Validation**: Clients MUST validate that `metadata.url` and endpoint URLs are properly formatted URLs
-
-3. **Size Limits**: Implementations SHOULD enforce reasonable size limits on the discovery document (e.g., 2MB) to prevent denial-of-service attacks
-
-4. **Access Control**: Implementations SHOULD have an unprotected discovery document, but MAY implement access control for the linked metadata files
+1. **HTTPS Required**: SHOULD require HTTPS for all URLs to prevent man-in-the-middle attacks
+2. **URL Validation**: Clients MUST validate `metadata.url` and endpoint URLs are properly formatted
+3. **Size Limits**: SHOULD enforce reasonable limits on discovery documents (e.g., 2MB) to prevent DoS attacks
+4. **Access Control**: Discovery documents SHOULD be unprotected; MAY protect linked metadata files
 
 ## Open Questions
 
@@ -384,156 +339,85 @@ This approach could be rejected or be allowed as an alternative to the .well-kno
 
 | Standard | Endpoint | Scope | Single/Multi-Service | Relationship to This SEP |
 |----------|----------|-------|----------------------|-------------------------|
-| **A2A Agent Discovery** | `/.well-known/agent.json` | A2A agents only | Single-service | This SEP enables multi-agent discovery |
-| **MCP SEP-2127** | `/.well-known/mcp/server-card.json` | MCP servers only | Single-service | This SEP enables multi-server discovery |
-| **RFC 9727 (API Catalog)** | `/.well-known/api-catalog` | All API types | Multi-service | Generic, not AI-protocol-aware |
-| **ORD** | `/.well-known/open-resource-discovery` | APIs, Events, Data Products | Multi-service | Enterprise-grade, broader scope than AI |
+| **[A2A Agent Discovery](#a2a-well-knownagentjson)** | `/.well-known/agent.json` | A2A agents only | Single-service | This SEP enables multi-agent discovery |
+| **[MCP SEP-2127](#mcp-sep-2127-mcp-server-cards---http-server-discovery)** | `/.well-known/mcp/server-card.json` | MCP servers only | Single-service | This SEP enables multi-server discovery |
+| **[RFC 9727](#rfc-9727-well-knownapi-catalog)** | `/.well-known/api-catalog` | All API types | Multi-service | Generic, not AI-protocol-aware |
+| **[ORD](#open-resource-discovery-well-knownopen-resource-discovery)** | `/.well-known/open-resource-discovery` | APIs, Events, Data Products | Multi-service | Enterprise-grade, broader scope than AI |
 
 ### MCP SEP-2127: MCP Server Cards - HTTP Server Discovery
 
-- **Issue**: [#1649](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649)
-- **Pull Request**: [#2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127)
-- **Proposed Endpoint**: `/.well-known/mcp/server-card.json` (single server assumption)
-
-SEP-2127 proposes a comprehensive MCP Server Card format including:
+[SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127) proposes a comprehensive MCP Server Card format including:
 - Server identification and versioning
 - Transport configuration (streamable-http, stdio, SSE)
 - Capabilities (tools, prompts, resources)
 - Authentication requirements
-- Static or dynamic primitive declarations
-- Protocol version information
+
+Proposed at `/.well-known/mcp/server-card.json` with a **single-server assumption**.
 
 **Relationship to this SEP:**
-- SEP-2127's card format provides excellent detail on **what metadata to include**
-- This SEP addresses **how to discover** that metadata, especially when multiple servers/agents exist
-- The MCP Server Card format should evolve from MCP Registry's `server.json`, enhanced with SEP-2127's additions
-- Discovery should use this SEP's shared `/.well-known/ai-cards.json` mechanism rather than protocol-specific endpoints
+- SEP-2127 defines **what metadata to include** in server cards
+- This SEP addresses **how to discover** multiple servers on a single host
+- Discovery uses `/.well-known/ai-cards.json` pointing to individual server card files
 
 ### MCP Registry server.json Format
-- **Repository**: [modelcontextprotocol/registry](https://github.com/modelcontextprotocol/registry)
-- **JSON Schema**: [2025-12-11.json](https://github.com/modelcontextprotocol/registry/blob/main/internal/validators/schemas/2025-12-11.json)
-- **Current use**: Registry entries for MCP servers
-- **Limitations**: Missing tools, prompts, resources definitions
 
-**Relationship to this SEP:**
-- Provides the foundation for MCP Server Card format
-- Needs enhancement with primitives (tools, prompts, resources, etc.) as proposed in SEP-2127
-- Would be discoverable via `metadata.url` in this proposal
+The [MCP Registry `server.json` format](https://github.com/modelcontextprotocol/registry/blob/main/internal/validators/schemas/2025-12-11.json) provides a foundation for MCP Server Cards but lacks tools, prompts, and resources. It should be enhanced (per SEP-2127) and made discoverable via `metadata.url`.
 
 ### A2A: `/.well-known/agent.json`
 
-- **Issue**: [IANA Well-Known URI Registration](https://github.com/protocol-registries/well-known-uris/issues/66)
-- **Specification**: [A2A Protocol](https://a2a-protocol.org/latest/specification/)
-- **Endpoint**: `/.well-known/agent.json` (singular - one agent assumption)
-- **Status**: Registered/In progress with IANA
+A2A has defined [`/.well-known/agent.json`](https://a2a-protocol.org/latest/specification/) ([IANA registration](https://github.com/protocol-registries/well-known-uris/issues/66)) for agent discovery.
 
-A2A has defined a well-known URI for agent discovery with comprehensive A2A Agent Cards including:
+**A2A Agent Cards include:**
 - Agent identification and metadata
 - Capabilities and supported operations
 - Authentication and authorization requirements
 - Endpoint information
 
 **Relationship to this SEP:**
-- A2A's agent card format is well-defined and should remain A2A-owned
-- The `/.well-known/agent.json` endpoint assumes one agent per host (singular filename)
-- This SEP enables discovery of **multiple agents** on a single host
-- The `metadata.url` in this proposal can point to individual A2A Agent Card files
+- A2A's card format remains **A2A-owned** and unchanged
+- The single-agent assumption is addressed by this SEP
+- `metadata.url` in the discovery document points to individual Agent Card files
+- Enables discovery of **multiple agents** on a single host
 
 ### RFC 9727: `/.well-known/api-catalog`
 
-- **RFC**: [RFC 9727](https://datatracker.ietf.org/doc/rfc9727/)
-- **Endpoint**: `/.well-known/api-catalog`
-- **Format**: Linkset (application/linkset+json) per RFC 9264
-- **Scope**: Generic API discovery across all API types
-- **Status**: Published IETF Standards Track (June 2025)
+[RFC 9727](https://datatracker.ietf.org/doc/rfc9727/) (IETF Standards Track, June 2025) defines generic API discovery using Linkset format for **any API type** (REST, GraphQL, SOAP).
 
-RFC 9727 defines a well-known URI for discovering **any** APIs published by a domain, using a Linkset format that provides:
-- Links to API endpoints (`item` relation)
-- Links to API descriptions (OpenAPI specs via `service-desc`)
-- Links to documentation (`service-doc`)
-- Metadata about APIs (`service-meta`)
-- Support for nested catalogs
+**Key differences from this SEP:**
 
-**Relationship to this SEP:**
+| Aspect | RFC 9727 | This SEP |
+|--------|----------|----------|
+| **Scope** | Generic APIs (REST, GraphQL, SOAP, etc.) | AI-native protocols (MCP, A2A) |
+| **Protocol Awareness** | Protocol-agnostic | Protocol-specific (`type: mcp` vs `type: a2a`) |
+| **Metadata** | Links to OpenAPI specs, generic docs | Links to AI-specific card formats (MCP Server Cards, A2A Agent Cards) |
 
-**Similarities:**
-- Both use `.well-known` URIs for discovery
-- Both support multiple services per host (RFC 9727 via Linkset arrays)
-- Both enable machine-readable discovery
-
-**Key Differences:**
-
-1. **Scope**: 
-   - RFC 9727: **Generic API catalog** - works for REST APIs, GraphQL, SOAP, or any API type
-   - This SEP: **AI-native protocol discovery** - specifically for MCP servers and A2A agents
-
-2. **Protocol Awareness**:
-   - RFC 9727: **Protocol-agnostic** - doesn't specify what protocol or metadata format the APIs use (only mediaType like `application/json`)
-   - This SEP: **Protocol-specific** - explicitly identifies `protocolType` (mcp, a2a) and the metadata format and links to protocol-specific metadata
-
-3. **Metadata Structure**:
-   - RFC 9727: Links to generic metadata (OpenAPI specs, docs) using standard link relations
-   - This SEP: Points to protocol-specific card formats (MCP Server Cards, A2A Agent Cards) that include protocol-specific capabilities
+**Relationship**: RFC 9727 is too generic for AI protocol discovery; this SEP provides AI-specific protocol identification and metadata.
 
 ### Open Resource Discovery: `.well-known/open-resource-discovery`
 
-- **Specification**: [Open Resource Discovery (ORD)](https://open-resource-discovery.org/spec-v1)
-- **Governance**: Linux Foundation
-- **Endpoint**: `/.well-known/open-resource-discovery`
-- **Scope**: Enterprise-grade discovery of APIs, Events, Data Products, Domain Objects, Taxonomy and more
-- **Complexity**: Comprehensive, feature-rich standard
- 
-ORD is an **enterprise-grade** discovery protocol that provides comprehensive resource discovery capabilities far beyond simple API discovery:
+[ORD](https://open-resource-discovery.org/spec-v1) (Linux Foundation) is an enterprise-grade discovery protocol for APIs, events, data products, domain objects, and taxonomy.
 
-**ORD Capabilities:**
-- **API Resources**: REST APIs, MCP, A2A, OData, GraphQL, etc.
-- **Event Resources**: Cloud Events, AsyncAPI, etc.
-- **Data Products**: Data sets, data models, Delta Sharing, etc.
-- **Domain Objects**: Business entities and domain models
-- **Static vs Dynamic Perspectives**: Distinguishes between system-type-level (static) and system-instance-level (tenant-specific, runtime) metadata
-- **Aggregation**: Complex aggregation capabilities for multi-system landscapes
-- **Access Strategies**: Multiple authentication and authorization patterns
+**ORD capabilities include:**
+- Comprehensive resource types (APIs, events, data products, domain objects)
+- Static vs dynamic perspectives (system-type vs tenant-specific)
+- Aggregation across multi-system landscapes
+- Access strategies and governance
 
 **Relationship to this SEP:**
 
-**ORD can handle AI protocol discovery today:**
-- ORD's flexible resource model already represents MCP servers and A2A agents as "API Resources". Agents can be described as dedicated entity to describe and govern the non-technical, product qualities.
-- ORD's static/dynamic perspectives can distinguish between server/agent capabilities and tenant-specific configurations
-- ORD provides a shared high-level meta-model across API protocols and even resource types
-- ORD's taxonomy can categorize AI resources
+ORD **can** handle AI protocol discovery today, but targets a different audience:
 
-**Why this SEP is still valuable:**
+| Aspect | ORD | This SEP |
+|--------|-----|----------|
+| **Target Audience** | Enterprise IT, governance teams | AI developers |
+| **Scope** | APIs, events, data products, taxonomy | AI protocols only (MCP, A2A) |
+| **Complexity** | Comprehensive, extensive specification | Simple (5 required fields) |
+| **Adoption Barrier** | High (complex data models) | Low (small JSON schema) |
 
-1. **Simplicity vs Complexity**:
-   - ORD: Enterprise-grade with extensive features (perspectives, aggregation, taxonomy, access strategies)
-   - This SEP: **Simple, focused** - just protocol type, endpoints, and metadata URL
-   - AI Card implementers want **minimal overhead**, not enterprise complexity
-
-2. **Scope Focus**:
-   - ORD: **Broad** - APIs, events, data products, domain objects, business taxonomy
-   - This SEP: **Narrow** - AI protocols only (MCP, A2A, future AI protocols)
-   - AI registries don't need data products, domain objects, or business taxonomy
-
-3. **Adoption Barrier**:
-   - ORD: Requires understanding extensive specification, implementing complex data models
-   - This SEP: Small JSON Schema contract, 5 required fields per protocol (type, endpoints, metadata with type and url)
-   - Lower barrier → faster ecosystem adoption
-
-4. **Protocol Specificity**:
-   - ORD: Generic resource discovery (protocol-agnostic)
-   - This SEP: **Protocol-aware** - explicitly identifies MCP vs A2A with protocol-specific card links
-   - Makes it trivial for AI clients to distinguish tools from agents
-
-5. **Target Audience**:
-   - ORD: **Enterprise IT** - managing complex multi-system landscapes holistically with governance requirements
-   - This SEP: **AI developers** - building and discovering AI agents and tools quickly
-
-**Could they coexist?**
-
-Yes, they target different audiences:
-- **Enterprise environments** with ORD: Could list AI Cards as one category of API resources within ORD
-- **AI-focused environments**: Implement lightweight `/.well-known/ai-cards.json` without ORD overhead
-- **Hybrid**: Implement both - ORD for comprehensive enterprise discovery, AI Cards for simple AI-specific discovery
+**Coexistence options:**
+- **Enterprise environments**: Use ORD for comprehensive discovery
+- **AI-focused environments**: Use lightweight `/.well-known/ai-cards.json`
+- **Hybrid deployments**: Implement both as needed
 
 ## Related Work
 

--- a/seps/0000-ai-card-discovery.md
+++ b/seps/0000-ai-card-discovery.md
@@ -1,7 +1,7 @@
 ---
 SEP: 0000
 Title: AI Card Discovery via Well-Known URI
-Author: [Simon Heimler] <simon.heimler@sap.com>
+Author: Simon Heimler <simon.heimler@sap.com>
 Status: draft
 Type: Standards Track
 Created: 2026-01-24
@@ -33,7 +33,7 @@ Both share a critical **single-service assumption**: one agent or server per hos
 **This breaks down in real-world scenarios:**
 - A host needs to expose multiple specialized services (e.g., petstore + inventory MCP servers, or sales + support A2A agents)
 - A platform provides both MCP servers and A2A agents
-- Registries must discover all available services, not just a "primary" one
+- Registries ideally cover both both Agents and Tools (MCP) together, as agents often rely on external tools and other agents.
 
 ### The Problem: Discovery Fragmentation
 
@@ -47,7 +47,7 @@ Having separate protocol-specific endpoints creates additional friction:
 This SEP provides a **single, protocol-agnostic discovery endpoint** (`/.well-known/ai-cards.json`) that:
 1. Enables **multi-service discovery** (multiple MCP servers and/or A2A agents per host)
 2. Enables **multi-protocol discovery** (single request reveals all AI capabilities)
-3. Allows each protocol to **maintain full ownership** of their metadata formats
+3. Allows each protocol to **maintain full ownership** and separate lifecycle of their metadata formats
 
 ## Specification
 
@@ -55,7 +55,7 @@ This SEP provides a **single, protocol-agnostic discovery endpoint** (`/.well-kn
 
 Services supporting AI Card discovery MUST provide a JSON document at `/.well-known/ai-cards.json`.
 
-By appending `.json` it is easier to host this and the linked metadata files on a static file server.
+> By appending `.json` it is easier to host this and the linked metadata files on a static file server.
 
 ### Discovery Document Format
 
@@ -103,11 +103,13 @@ The discovery document MUST be a JSON object following the [ai-card-v0.schema.js
 URLs in the discovery document (both `endpoints[].url` and `metadata.url`) **MAY be relative or absolute**.
 
 #### Absolute URLs
+
 Absolute URLs include the full protocol and authority:
 - `https://example.com/mcp-endpoint`
 - `https://api.example.com/.well-known/petstore.mcp.json`
 
 #### Relative URLs
+
 Relative URLs are resolved **relative to the location of the discovery document** (`/.well-known/ai-cards.json`), following [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) URL resolution rules:
 
 **Path-relative URLs** (start with `./` or `../`):
@@ -118,17 +120,6 @@ Relative URLs are resolved **relative to the location of the discovery document*
 **Absolute-path URLs** (start with `/`):
 - `/api/mcp` → resolves to `/api/mcp` (relative to host root)
 - `/metadata/petstore.mcp.json` → resolves to `/metadata/petstore.mcp.json`
-
-#### URL Resolution Examples
-
-For a discovery document served at `https://example.com/.well-known/ai-cards.json`:
-
-| URL Type | Example in Document | Resolves To |
-|----------|---------------------|-------------|
-| Absolute | `https://api.example.com/mcp` | `https://api.example.com/mcp` |
-| Path-relative | `./petstore.mcp.json` | `https://example.com/.well-known/petstore.mcp.json` |
-| Path-relative | `../metadata/server.json` | `https://example.com/metadata/server.json` |
-| Absolute-path | `/api/mcp` | `https://example.com/api/mcp` |
 
 **Recommendation**: Use relative URLs when metadata and endpoints are co-located with the discovery document. Use absolute URLs when pointing to external services or different domains.
 
@@ -150,8 +141,8 @@ Each protocol community maintains **full ownership** of their metadata format. T
 #### Scope of This SEP
 
 This SEP **intentionally does not mandate** any particular structure for metadata files. It only standardizes:
-1. How to **discover** multiple services on a single host
-2. How to **identify** protocol types (`type` field)
+1. How to **discover** multiple AI protocols and metadata files on a single host
+2. How to **identify** protocol and metadata format types (`type` field)
 3. How to **locate** metadata files (`metadata.url` field)
 
 The scope could be expanded in the future to indicate version(s) of protocols and metadata formats (see Open Questions).
@@ -165,28 +156,11 @@ Rather than creating a unified card format for MCP and A2A, this SEP keeps card 
 - Potential compromises that don't serve either protocol well
 - Slower evolution requiring multi-party consensus
 
-### Design Principles
-
-**Minimal Coordination Surface**: This SEP minimizes cross-protocol coordination to just three pieces of information:
-1. Protocol type identifier (the `type` field)
-2. Connection endpoints (the `endpoints` array)  
-3. Metadata location (the `metadata` object with `type` and `url`)
-
-Each protocol maintains **full ownership** of their card formats and can evolve independently.
-
-**Standard Discovery Pattern**: Uses the well-established `.well-known` URI scheme ([RFC 8615](https://www.rfc-editor.org/rfc/rfc8615)) for decentralized, client-initiated discovery without requiring centralized registries.
-
 ### Integration with Existing Mechanisms
 
-This SEP **coexists** with protocol-specific discovery endpoints:
-- A2A's `/.well-known/agent.json`
-- MCP's proposed `/.well-known/mcp/server-card.json` (SEP-2127)
-
-**How it works:**
-- The `protocols` array enables multi-service discovery
-- `metadata.url` can point to protocol-specific card files
-- Single-protocol deployments can use protocol-specific endpoints
-- Multi-protocol deployments and registries benefit from unified discovery at `/.well-known/ai-cards.json`
+This SEP coexists or supersedes protocol-specific discovery endpoints:
+- A2A's `/.well-known/agent.json` (coexists)
+- MCP's proposed `/.well-known/mcp/server-card.json` (SEP-2127) (supersedes)
 
 ## Backward Compatibility
 
@@ -199,78 +173,27 @@ This is a new feature and does not introduce backward compatibility concerns. Se
 ## Security Implications
 
 1. **HTTPS Required**: SHOULD require HTTPS for all URLs to prevent man-in-the-middle attacks
-2. **URL Validation**: Clients MUST validate `metadata.url` and endpoint URLs are properly formatted
-3. **Size Limits**: SHOULD enforce reasonable limits on discovery documents (e.g., 2MB) to prevent DoS attacks
-4. **Access Control**: Discovery documents SHOULD be unprotected; MAY protect linked metadata files
+2. **Size Limits**: SHOULD enforce reasonable limits on discovery documents (e.g., 2MB) to prevent DoS attacks
+3. **Access Control**: Well-known discovery entry-point SHOULD be unprotected; linked metadata files MAY be protected
 
 ## Open Questions
 
 ### 1. Protocol Versioning Strategy
 
-**Question**: Should the protocol `type` field include version information (e.g., `"mcp/v1"`, `"a2a/v2"`)?
+**Question**: If a service supports multiple versions of a protocol (e.g., MCP v1 and v2), how should this be represented?
+Should the protocol `type` field include version information (e.g., `"mcp/v1"`, `"a2a/v2"`)?
 
 **Options**:
 - **A)** Include in `type`: `"mcp/v1"`, `"a2a/v2"`
 - **B)** Separate `version` field: `{"type": "mcp", "version": "1.0"}`
-- **C)** Only in metadata files: Extract from `$schema` or dedicated version field
+- **C)** Only in metadata files or protocol endpoint: Extract it from the linked metadata files or by connecting to endpoint where server will respond with the version(s) of the protocol it implements
 
 **Trade-offs**:
 - Option A enables protocol version filtering without fetching metadata
-- Option C keeps discovery simpler but requires metadata fetch to determine version
 - Option B provides structured versioning but adds a required field
+- Option C keeps discovery simpler but requires metadata fetch to determine version
 
-**Recommendation needed**: How important is version-based filtering at the discovery layer?
-
-### 2. Metadata Format Versioning
-
-**Question**: How should clients determine which version of a metadata format (e.g., MCP Server Card schema) is being used?
-
-**Options**:
-- **A)** Add `metadata.schemaVersion` field in discovery document
-- **B)** Rely on `$schema` field within the metadata file itself
-- **C)** Include version in `metadata.type`: `"mcp-server-card-v1"`
-
-**Impact**: Affects whether clients can validate compatibility before fetching metadata files.
-
-### 3. Supporting Multiple Protocol Versions
-
-**Question**: If a service supports multiple versions of a protocol (e.g., MCP v1 and v2), how should this be represented?
-
-**Options**:
-- **A)** Separate entries in `protocols` array (one per version)
-- **B)** Single entry with version negotiation at connection time
-- **C)** List supported versions within the metadata file
-
-**Example scenario**: A server supports both legacy clients (MCP v1) and new clients (MCP v2).
-
-### 4. Governance and Coordination
-
-**Question**: Should this SEP be:
-- **A)** Proposed to MCP community (as MCP SEP) with A2A adoption?
-- **B)** Maintained as separate cross-protocol specification?
-- **C)** Submitted to IETF/W3C as a broader standard?
-
-**Adoption strategy**: How do we ensure both MCP and A2A ecosystems adopt this approach?
-
-### 5. Registry Discovery Requirements
-
-**Question**: Should registries that index multiple protocols:
-- **A)** **Require** `/.well-known/ai-cards.json` as primary discovery
-- **B)** **Support** both AI Cards and protocol-specific endpoints (e.g., `/.well-known/agent.json`)
-- **C)** **Also support** advanced protocols like ORD for enterprise environments
-
-**Recommendation**: Option B provides maximum compatibility during transition period.
-
-### 6. Registry Data Model Separation
-
-**Question**: How should registry-specific metadata (ratings, download counts, verification status) be handled?
-
-**Proposal**: Clarify that:
-- **Service metadata** (MCP Server Cards, A2A Agent Cards) describes the service itself
-- **Registry metadata** (ratings, stats) is a registry concern, potentially a superset model
-- Registries are **optional** and can define their own API/data models
-
-### 7. Access Control for Metadata
+### 2. Access Control for Metadata
 
 **Question**: Should the discovery document indicate when metadata requires authentication?
 
@@ -279,7 +202,7 @@ This is a new feature and does not introduce backward compatibility concerns. Se
 - **B)** Clients discover through HTTP 401/403 responses
 - **C)** No indication - assume public discovery, protected metadata requires docs
 
-### 8. Dynamic and Tenant-Specific Metadata
+### 3. Dynamic and Tenant-Specific Metadata
 
 **Question**: How should dynamic or tenant-specific metadata be handled?
 

--- a/seps/0000-ai-card-discovery.schema.json
+++ b/seps/0000-ai-card-discovery.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ai-card.org/schemas/ai-card-v0.schema.json",
+  "title": "AI Card Discovery Document",
+  "description": "Discovery document for AI-native protocols (MCP, A2A, etc.) exposed by a host via /.well-known/ai-cards.json",
+  "type": "object",
+  "required": ["protocols"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "URI reference to the JSON Schema for this document",
+      "format": "uri",
+      "examples": [
+        "https://ai-card.org/schemas/ai-card-v0.schema.json"
+      ]
+    },
+    "protocols": {
+      "type": "array",
+      "description": "Array of protocol objects describing AI-native protocols (servers/agents) available on this host. A single host can expose multiple MCP servers and/or multiple A2A agents.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/protocol"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "protocol": {
+      "type": "object",
+      "description": "Describes a single MCP server or A2A agent exposed by this host",
+      "required": ["protocolType", "endpoints", "metadata"],
+      "properties": {
+        "protocolType": {
+          "type": "string",
+          "description": "The AI protocol type identifier. Current values: 'mcp' for Model Context Protocol servers, 'a2a' for Agent-to-Agent agents. Future AI protocols may be added.",
+          "enum": ["mcp", "a2a"],
+          "examples": ["mcp", "a2a"]
+        },
+        "endpoints": {
+          "type": "array",
+          "description": "Array of endpoint objects where this protocol server/agent can be accessed",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/endpoint"
+          }
+        },
+        "metadata": {
+          "$ref": "#/$defs/metadata",
+          "description": "Reference to the protocol-specific card metadata file (MCP Server Card or A2A Agent Card)"
+        }
+      },
+      "additionalProperties": false,
+      "examples": [
+        {
+          "protocolType": "mcp",
+          "endpoints": [
+            {
+              "url": "https://example.com/mcp/petstore"
+            }
+          ],
+          "metadata": {
+            "url": "https://example.com/.well-known/petstore.mcp.json"
+          }
+        },
+        {
+          "protocolType": "a2a",
+          "endpoints": [
+            {
+              "url": "https://api.example.com/agents/customer-service"
+            }
+          ],
+          "metadata": {
+            "url": "https://api.example.com/.well-known/CustomerServiceAgent.json"
+          }
+        }
+      ]
+    },
+    "endpoint": {
+      "type": "object",
+      "description": "A single endpoint URL where the protocol can be accessed",
+      "required": ["url"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The endpoint URL where this protocol server/agent can be accessed. May be absolute (https://...) or relative (./path, /path). Relative URLs are resolved relative to the location of the discovery document (/.well-known/ai-cards.json). For example, ./mcp-endpoint resolves to /.well-known/mcp-endpoint, and /api/mcp resolves to /api/mcp.",
+          "pattern": "^(https?://|/|\\./)",
+          "examples": [
+            "https://example.com/mcp-endpoint",
+            "https://api.example.com/agents/customer-service",
+            "/api/mcp",
+            "./mcp-endpoint",
+            "../mcp/server"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Reference to protocol-specific card metadata. The structure of the metadata file is owned and defined by the protocol community (MCP or A2A). This SEP only defines the discovery mechanism.",
+      "required": ["url"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL to the protocol-specific card metadata file. May be absolute (https://...) or relative (./path, /path). Relative URLs are resolved relative to the location of the discovery document (/.well-known/ai-cards.json). For example, ./petstore.mcp.json resolves to /.well-known/petstore.mcp.json. For MCP: points to an MCP Server Card. For A2A: points to an A2A Agent Card.",
+          "pattern": "^(https?://|/|\\./)",
+          "examples": [
+            "https://example.com/.well-known/petstore.mcp.json",
+            "https://api.example.com/metadata/CustomerServiceAgent.json",
+            "./petstore.mcp.json",
+            "./PetAgent.json",
+            "/metadata/inventory.mcp.json"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/seps/0000-ai-card-discovery.schema.json
+++ b/seps/0000-ai-card-discovery.schema.json
@@ -28,9 +28,9 @@
     "protocol": {
       "type": "object",
       "description": "Describes a single MCP server or A2A agent exposed by this host",
-      "required": ["protocolType", "endpoints", "metadata"],
+      "required": ["type", "endpoints", "metadata"],
       "properties": {
-        "protocolType": {
+        "type": {
           "type": "string",
           "description": "The AI protocol type identifier. Current values: 'mcp' for Model Context Protocol servers, 'a2a' for Agent-to-Agent agents. Future AI protocols may be added.",
           "enum": ["mcp", "a2a"],
@@ -52,24 +52,26 @@
       "additionalProperties": false,
       "examples": [
         {
-          "protocolType": "mcp",
+          "type": "mcp",
           "endpoints": [
             {
               "url": "https://example.com/mcp/petstore"
             }
           ],
           "metadata": {
+            "type": "mcp-server-card",
             "url": "https://example.com/.well-known/petstore.mcp.json"
           }
         },
         {
-          "protocolType": "a2a",
+          "type": "a2a",
           "endpoints": [
             {
               "url": "https://api.example.com/agents/customer-service"
             }
           ],
           "metadata": {
+            "type": "agent-card",
             "url": "https://api.example.com/.well-known/CustomerServiceAgent.json"
           }
         }
@@ -98,8 +100,14 @@
     "metadata": {
       "type": "object",
       "description": "Reference to protocol-specific card metadata. The structure of the metadata file is owned and defined by the protocol community (MCP or A2A). This SEP only defines the discovery mechanism.",
-      "required": ["url"],
+      "required": ["type", "url"],
       "properties": {
+        "type": {
+          "type": "string",
+          "description": "The metadata card type. Identifies the format/schema of the metadata file. Current values: 'mcp-server-card' for MCP Server Cards, 'agent-card' for A2A Agent Cards. Future card types may be added.",
+          "enum": ["mcp-server-card", "agent-card"],
+          "examples": ["mcp-server-card", "agent-card"]
+        },
         "url": {
           "type": "string",
           "description": "URL to the protocol-specific card metadata file. May be absolute (https://...) or relative (./path, /path). Relative URLs are resolved relative to the location of the discovery document (/.well-known/ai-cards.json). For example, ./petstore.mcp.json resolves to /.well-known/petstore.mcp.json. For MCP: points to an MCP Server Card. For A2A: points to an A2A Agent Card.",

--- a/seps/0014-ai-card-discovery.md
+++ b/seps/0014-ai-card-discovery.md
@@ -1,5 +1,5 @@
 ---
-SEP: 0000
+SEP: 0014
 Title: AI Card Discovery via Well-Known URI
 Author: Simon Heimler <simon.heimler@sap.com>
 Status: draft


### PR DESCRIPTION
This SEP proposes a standardized discovery mechanism for AI-native protocols (MCP and A2A) using a `.well-known` URI endpoint. 

It makes a strong assumption that MCP and A2A do not create a shared model, each will own its own "card" metadata files. But we can still share the discovery mechanism between the two (and potentially other / upcoming) protocols.

## Problem

Both MCP and A2A protocols have defined protocol-specific discovery endpoints that:
- Assume **one server/agent per host** (MCP: `/.well-known/mcp/server-card.json`, A2A: `/.well-known/agent.json`)
- Require clients to probe multiple endpoints for multi-protocol discovery
- Create ecosystem fragmentation

## Solution

A single, protocol-agnostic discovery endpoint at `/.well-known/ai-cards.json` that:
- Supports **multiple MCP servers and/or A2A agents** per host
-  Enables single-request multi-protocol discovery
- Maintains protocol autonomy (each protocol owns its card format)
- Uses simple JSON Schema with 5 required fields per protocol
- Supports both relative and absolute URLs

## Example

```json
{
  "$schema": "https://ai-card.org/schemas/ai-card-v0.schema.json",
  "protocols": [
    {
      "type": "mcp",
      "endpoints": [{"url": "./mcp-petstore"}],
      "metadata": {
        "type": "mcp-server-card",
        "url": "./petstore.mcp.json"
      }
    },
    {
      "type": "a2a",
      "endpoints": [{"url": "/agents/support"}],
      "metadata": {
        "type": "agent-card",
        "url": "/metadata/SupportAgent.json"
      }
    }
  ]
}