### PR TITLE
Add AI Catalog governance proposal

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -70,7 +70,7 @@ behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
 
 Reports should be directed to
-[conduct@ai-catalog.example](mailto:conduct@ai-catalog.example), a temporary
+<TBD>, a temporary
 contact address for the AI Catalog project. It is the responsibility of the
 project maintainers to receive and address reported violations of the Code of
 Conduct. They may work with project leadership as needed to investigate and

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,93 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in this project and
+its community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing the project or community include using an official project email
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of the
+project may be further defined and clarified by project maintainers.
+
+This Code of Conduct also applies outside the project spaces when the project
+maintainers have a reasonable belief that an individual's behavior may have a
+negative impact on the project or its community.
+
+## Conflict Resolution
+
+We do not believe that all conflict is bad; healthy debate and disagreement
+often yield positive results. However, it is never okay to be disrespectful or
+to engage in behavior that violates this Code of Conduct.
+
+If you see someone violating the Code of Conduct, you are encouraged to address
+the behavior directly with those involved. Many issues can be resolved quickly
+and easily, and this gives people more control over the outcome of their
+dispute. If you are unable to resolve the matter for any reason, or if the
+behavior is threatening or harassing, report it. We are dedicated to providing
+an environment where participants feel welcome and safe.
+
+Reports should be directed to
+[conduct@ai-catalog.example](mailto:conduct@ai-catalog.example), a temporary
+contact address for the AI Catalog project. It is the responsibility of the
+project maintainers to receive and address reported violations of the Code of
+Conduct. They may work with project leadership as needed to investigate and
+resolve reports.
+
+We will investigate every complaint, but you may not receive a direct response.
+We will use our discretion in determining when and how to follow up on reported
+incidents, which may range from not taking action to permanent expulsion from
+the project and project-sponsored spaces. We will notify the accused of the
+report and provide them an opportunity to discuss it before any action is
+taken. The identity of the reporter will be omitted from the details of the
+report supplied to the accused. In potentially harmful situations, such as
+ongoing harassment or threats to anyone's safety, we may take action without
+notice.
+
+## Attribution
+
+This Code of Conduct is adapted from the A2A project Code of Conduct, which is
+adapted from the Contributor Covenant, version 1.4, available at
+<https://www.contributor-covenant.org/version/1/4/code-of-conduct/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing
+
+Thank you for contributing to the AI Catalog project.
+
+This repository is currently used to develop the AI Catalog specification in
+public. The canonical specification source lives in
+the files under `specification/cddl/`, and changes are reviewed through GitHub
+pull requests.
+
+## Ways To Contribute
+
+- open an issue to report a bug, gap, or editorial problem
+- start a discussion for broader design questions or cross-project alignment
+- send a pull request with a proposed change to the specification, examples, or
+  build tooling
+
+For substantial specification changes, open an issue or discussion first so the
+proposed direction can be reviewed before detailed text is drafted.
+
+## Repository Layout
+
+- `GOVERNANCE.md`: project governance and working rules
+- `specification/cddl/`: specification source files and comparison material
+- `specification/examples/`: example AI Catalog documents
+
+Use the current repository contents as the source of truth when deciding where a
+change belongs.
+
+## Development Setup
+
+To contribute to this repository, install:
+
+- Python 3.12 or later
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
+- Git
+
+If your change depends on new tooling or build steps, document that in the same
+pull request.
+
+## Working On Specification Changes
+
+Most contribution work in this repository involves editing the specification
+files and updating related examples.
+
+### What To Update
+
+When proposing a specification change, update the relevant supporting material
+in the same pull request when applicable:
+
+- specification files under `specification/cddl/`
+- examples under `specification/examples/`
+- explanatory text in `README.md`
+- governance or process documents when the change affects project workflow
+
+## Pull Request Workflow
+
+1. Create a feature branch for your change.
+2. Make the smallest coherent set of edits needed for the proposal.
+3. Review the changed specification text and examples carefully before opening
+  the pull request.
+4. Commit using a conventional commit message.
+5. Open a pull request for review.
+6. Address reviewer feedback in follow-up commits.
+
+Current repository practice is to keep work off `main` and submit changes
+through pull requests.
+
+For security reasons, pull requests opened from forks do not generate PR
+previews. If preview deployment is enabled for same-repository branches, it is
+limited to branches in the main repository, which typically means
+maintainer-managed branches.
+
+## Commit Guidance
+
+- use [Conventional Commits](https://www.conventionalcommits.org/)
+- keep commit scope focused
+- prefer signed and signed-off commits when contributing to the project
+
+Examples:
+
+- `docs: clarify well-known publication rules`
+- `spec: add trust metadata requirements`
+- `docs: add project security policy`
+
+## Review Expectations
+
+All substantive changes should go through pull request review. When proposing a
+specification update, explain:
+
+- what problem the change solves
+- whether it changes interoperability expectations
+- whether examples or generated output changed as a result
+
+## Questions
+
+If you are not sure where a change belongs, start with one of the existing
+public collaboration channels listed in `README.md` and propose the change in
+public first.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,8 @@ The AI Catalog project is governed by the Technical Steering Committee. The init
 
 | Company | Representative | Title | Contact |
 | :--- | :--- | :--- | :--- |
-|  |  |  |  |
+| Google | Junjie Bu | Senior Staff SWE | https://github.com/mindpower |
+| Microsoft | Darrel Miller | Partner API Architect | https://github.com/darrelmiller |
 
 ## Mission and Scope of the Project
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -46,7 +46,7 @@ While the Project aims to operate as a consensus-based community, if any TSC dec
 Quorum for TSC meetings requires a majority of all voting members of the TSC to be present. The TSC may continue to meet if quorum is not met but will be prevented from making any decisions at the meeting. Decisions by vote require a majority vote of all TSC members.
 
 ### TSC Meetings
-TSC Meetings are held on the Linux Foundation's meeting platform. [https://zoom-lfx.platform.linuxfoundation.org/meetings/aicatalog](https://zoom-lfx.platform.linuxfoundation.org/meeting/91656063701) has meeting details and recordings of past meetings.
+TSC Meetings are held on the Linux Foundation's meeting platform. [https://zoom-lfx.platform.linuxfoundation.org/meetings/aicatalog](https://zoom-lfx.platform.linuxfoundation.org/meeting/91656063701?password=946db53a-d3d4-4dd2-a8d5-5ed46ae035d3) has meeting details and recordings of past meetings.
 Agenda and meeting notes are posted in the [TSC Meeting Notes](https://docs.google.com/document/d/1RriqwfC6fcL5NbpGrFFHXfvonQiIsXrutGuwpnBlAwM/edit?tab=t.ub1ywahpk09y) document.
 
 ## Project Communications

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -23,7 +23,7 @@ The AI Catalog project is governed by the Technical Steering Committee. The init
 1. The Technical Steering Committee (the "TSC") will be responsible for all technical oversight of the open source Project.
 2. **TSC Composition**
 
-    a. **"Startup Phase."** At the inception of the Project, four TSC members will be nominated. Two will be nominated by MCP Maintainers (https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/MAINTAINERS.md) and two will be nominated by the the Linux Foundation A2A Technical Steering Committee (https://github.com/a2aproject/A2A/blob/main/GOVERNANCE.md).
+    a. **"Startup Phase."** At the inception of the Project, four TSC members will be nominated. Two will be nominated by MCP Core Maintainers (https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/MAINTAINERS.md) and two will be nominated by the the Linux Foundation A2A Technical Steering Committee (https://github.com/a2aproject/A2A/blob/main/GOVERNANCE.md).
 
     b. **"Steady State."** The TSC will decide upon a "steady state" composition of the TSC (whether by election, subproject technical leads, or other method as determined by the TSC).
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,56 @@
+# AI Catalog Governance
+
+The AI Catalog project is governed by the Technical Steering Committee. The initial Committee has four seats, each held by the following individuals:
+
+| Company | Representative | Title | Contact |
+| :--- | :--- | :--- | :--- |
+|  |  |  |  |
+
+## Mission and Scope of the Project
+
+1. The mission of the Project is to enable discovery of AI services and related artifacts. The Project includes collaborative development of the following components:
+
+   1. AI Catalog specification;
+
+   2. tooling related to validation of AI Catalogs, and transformation to and from the AI Catalog format; and
+
+   3. documentation and other artifacts related to the Project.
+
+2. The scope of the Project includes collaborative development under the Project License (as defined herein) supporting the mission, including documentation, testing, integration and the creation of other artifacts that aid the development, deployment, operation or adoption of the open source project.
+
+## Technical Steering Committee
+
+1. The Technical Steering Committee (the "TSC") will be responsible for all technical oversight of the open source Project.
+2. **TSC Composition**
+
+    a. **"Startup Phase."** At the inception of the Project, four TSC members will be nominated. Two will be nominated by MCP Maintainers (https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/MAINTAINERS.md) and two will be nominated by the the Linux Foundation A2A Technical Steering Committee (https://github.com/a2aproject/A2A/blob/main/GOVERNANCE.md).
+
+    b. **"Steady State."** The TSC will decide upon a "steady state" composition of the TSC (whether by election, subproject technical leads, or other method as determined by the TSC).
+
+    c. The TSC may choose an alternative approach for determining the voting members of the TSC, and any such alternative approach will be documented in the GOVERNANCE file. Any meetings of the Technical Steering Committee are intended to be open to the public, and can be conducted electronically, via teleconference, or in person.
+
+3. **Responsibilities:** The TSC will be responsible for all aspects of oversight relating to the Project, which may include:
+    1. coordinating the technical direction of the Project;
+    2. approving project or system proposals;
+    3. appointing representatives to work with other open source or open standards communities;
+    4. establishing community norms, workflows, issuing releases, and security issue reporting policies;
+    5. approving and implementing policies and processes for contributing (to be published in the [`CONTRIBUTING`](CONTRIBUTING.md) file - to follow);
+    6. discussions, seeking consensus, and where necessary, voting on technical matters relating to the code base that affect multiple projects; and
+    7. coordinating any marketing, events, or communications regarding the Project.
+
+### TSC Voting
+
+While the Project aims to operate as a consensus-based community, if any TSC decision requires a vote to move the Project forward, the voting members of the TSC will vote on a one vote per voting member basis.
+
+Quorum for TSC meetings requires a majority of all voting members of the TSC to be present. The TSC may continue to meet if quorum is not met but will be prevented from making any decisions at the meeting. Decisions by vote require a majority vote of all TSC members.
+
+### TSC Meetings
+TSC Meetings are held on the Linux Foundation's meeting platform. [https://zoom-lfx.platform.linuxfoundation.org/meetings/aicatalog](https://zoom-lfx.platform.linuxfoundation.org/meeting/91656063701) has meeting details and recordings of past meetings.
+Agenda and meeting notes are posted in the [TSC Meeting Notes](https://docs.google.com/document/d/1RriqwfC6fcL5NbpGrFFHXfvonQiIsXrutGuwpnBlAwM/edit?tab=t.ub1ywahpk09y) document.
+
+## Project Communications
+
+The AI Catalog project utilizes GitHub for conversations about the project. All are welcome and encouraged to participate on the [AI Catalog](http://github.com/Agent-Card/ai-card) repository.
+
+Any discussions about feature proposals, significant changes to the project architecture or governance, etc. should be held in GitHub with adequate notice and time for comment. Our goal is that GitHub is the source of truth for significant project decisions.
+

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -13,7 +13,7 @@ The AI Catalog project is governed by the Technical Steering Committee. The init
 
    1. AI Catalog specification;
 
-   2. tooling related to validation of AI Catalogs, and transformation to and from the AI Catalog format; and
+   2. Tooling related to validation of AI Catalogs, and transformation to and from the AI Catalog format; and
 
    3. documentation and other artifacts related to the Project.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -3,7 +3,7 @@
 The AI Catalog project is governed by the Technical Steering Committee. The initial Committee has four seats, each held by the following individuals:
 
 | Company | Representative | Contact |
-| :--- | :--- | :--- | :--- |
+| :--- | :--- | :--- |
 | Google | Junjie Bu | https://github.com/mindpower |
 | Microsoft | Darrel Miller | https://github.com/darrelmiller |
 | Anthropic | David Soria Parra | https://github.com/dsp-ant |

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,6 +8,7 @@ The AI Catalog project is governed by the Technical Steering Committee. The init
 | Microsoft | Darrel Miller | https://github.com/darrelmiller |
 | Anthropic | David Soria Parra | https://github.com/dsp-ant |
 | MCP Core maintainer nominee | TBD |  |
+| MCP Core maintainer nominee | TBD |  |
 ## Mission and Scope of the Project
 
 1. The mission of the Project is to enable discovery of AI services and related artifacts. The Project includes collaborative development of the following components:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,6 +7,7 @@ The AI Catalog project is governed by the Technical Steering Committee. The init
 | Google | Junjie Bu | https://github.com/mindpower |
 | Microsoft | Darrel Miller | https://github.com/darrelmiller |
 | Anthropic | David Soria Parra | https://github.com/dsp-ant |
+| MCP Core maintainer nominee | TBD |  |
 ## Mission and Scope of the Project
 
 1. The mission of the Project is to enable discovery of AI services and related artifacts. The Project includes collaborative development of the following components:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,7 +8,6 @@ The AI Catalog project is governed by the Technical Steering Committee. The init
 | Microsoft | Darrel Miller | https://github.com/darrelmiller |
 | Anthropic | David Soria Parra | https://github.com/dsp-ant |
 | MCP Core maintainer nominee | TBD |  |
-| MCP Core maintainer nominee | TBD |  |
 ## Mission and Scope of the Project
 
 1. The mission of the Project is to enable discovery of AI services and related artifacts. The Project includes collaborative development of the following components:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,11 +2,11 @@
 
 The AI Catalog project is governed by the Technical Steering Committee. The initial Committee has four seats, each held by the following individuals:
 
-| Company | Representative | Title | Contact |
+| Company | Representative | Contact |
 | :--- | :--- | :--- | :--- |
-| Google | Junjie Bu | Senior Staff SWE | https://github.com/mindpower |
-| Microsoft | Darrel Miller | Partner API Architect | https://github.com/darrelmiller |
-
+| Google | Junjie Bu | https://github.com/mindpower |
+| Microsoft | Darrel Miller | https://github.com/darrelmiller |
+| Anthropic | David Soria Parra | https://github.com/dsp-ant |
 ## Mission and Scope of the Project
 
 1. The mission of the Project is to enable discovery of AI services and related artifacts. The Project includes collaborative development of the following components:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,57 @@
+# Licensing
+
+Unless otherwise noted, this repository uses a split-license model.
+
+## Software And Code
+
+Software and code in this repository are licensed under the Apache License,
+Version 2.0.
+
+This includes source code, scripts, build logic, automation, workflow files,
+configuration used to build or validate the project, and similar executable or
+machine-readable assets.
+
+Examples include:
+
+- files under `tools/`
+- GitHub workflow files under `.github/`
+- project configuration such as `pyproject.toml` and `uv.lock`
+
+SPDX identifier: `Apache-2.0`
+
+Canonical license text:
+
+- <https://www.apache.org/licenses/LICENSE-2.0>
+
+## Specification And Documentation
+
+The specification and documentation in this repository are licensed under the
+Creative Commons Attribution 4.0 International License.
+
+This includes prose documentation, the specification text, examples, diagrams,
+and similar documentation assets unless a file states otherwise.
+
+Examples include:
+
+- `README.md`
+- files under `specification/`
+
+SPDX identifier: `CC-BY-4.0`
+
+Canonical license text:
+
+- <https://creativecommons.org/licenses/by/4.0/>
+- <https://creativecommons.org/licenses/by/4.0/legalcode>
+
+## Contributions
+
+By contributing to this repository, you agree that your contributions are
+licensed under the same terms that apply to the files you modify or add.
+
+If a contribution spans both categories, maintainers may ask contributors to
+clarify the intended licensing in the pull request.
+
+## Third-Party Content
+
+Any third-party content included in this repository remains subject to its own
+license notices and attribution requirements.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Members from various AI Protocols (MCP, A2A) are collaborating on a common AI ca
 
 Contact us via GitHub Discussions, [Issues](https://github.com/Agent-Card/ai-card/issues), and [Pull Requests](https://github.com/Agent-Card/ai-card/pulls).
 
+Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+
 ## What problem are we solving?
 
 There are multiple evolving standards for communication protocols between AI clients and servers. While these protocols differ in capabilities and technical architecture, there are common ecosystem needs for producers and consumers of services built on top of them. This includes discovery, verifiable metadata, and trusted identity standards.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Reporting A Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.
+
+Use GitHub's private vulnerability reporting flow for this repository:
+
+- <https://github.com/Agent-Card/ai-catalog/security/advisories/new>
+
+If private reporting is not available to you, contact the project maintainers
+privately through GitHub and request a secure channel before sharing sensitive
+details.
+
+When reporting a vulnerability, please include:
+
+- the affected component, file, or workflow
+- reproduction steps or a proof of concept
+- the expected security impact
+- any known mitigations or suggested fixes
+
+## Supported Versions
+
+Security fixes are provided on a best-effort basis for the default branch.
+
+| Branch or Version | Supported |
+| --- | --- |
+| `main` | Yes |
+| release tags | Best effort when applicable |
+| feature branches and preview deployments | No |
+
+## Scope
+
+Security reports are especially relevant for:
+
+- scripts and tooling under `tools/`
+- GitHub workflows and publication automation
+- generated preview and publishing behavior
+- any repository content that could affect integrity, provenance, or disclosure
+
+## Disclosure Process
+
+The maintainers will try to:
+
+- acknowledge receipt promptly
+- validate and triage the report
+- coordinate remediation and disclosure timing when appropriate
+
+Please avoid public disclosure until a fix or mitigation is available.


### PR DESCRIPTION
Proposes a governance structure for the AI Catalog project including:
- Technical Steering Committee composition and responsibilities
- Mission and scope definition
- Initial TSC seating from MCP and A2A communities