### PR TITLE
Clarify that the identity scheme set is open

### DIFF
--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -341,7 +341,8 @@ A Trust Manifest MUST contain:
 `identity`
 : A string containing a globally unique URI [[RFC3986]] that serves as
   the primary subject identifier for this artifact. This SHOULD be a
-  DID, SPIFFE ID, or URL.
+  DID, SPIFFE ID, or URL; these are illustrative and the set of
+  identity schemes is open.
 
 When a Trust Manifest appears within a Catalog Entry, the `identity`
 field MUST match the entry's `identifier` field. This binding ensures trust


### PR DESCRIPTION
## Summary

The Trust Manifest `identity` field lists `DID, SPIFFE ID, or URL` but does not state whether that list is exhaustive. This one-line clarification notes the examples are illustrative and the scheme set is open, so publishers/consumers can use other scheme-prefixed URIs without implying a spec change.

## Change

+2 / -1, one field:

```diff
  the primary subject identifier for this artifact. This SHOULD be a
-  DID, SPIFFE ID, or URL.
+  DID, SPIFFE ID, or URL; these are illustrative and the set of
+  identity schemes is open.
```

## Why

Feedback from Srinivas on federated discovery emphasized that DID is one identity option among several (with SPIFFE expected to predominate in enterprises). The richer federated-participation, enterprise-onboarding, indexing-flexibility, and caching guidance from that feedback lives in the Agent Finder discovery-layer docs; only this minimal openness clarification belongs in the lower-layer ai-catalog container spec.