### PR TITLE
spec: make Catalog Entry displayName optional (not required) (ADR 0016)

### DIFF
--- a/adr/0016-displayname-optional.md
+++ b/adr/0016-displayname-optional.md
@@ -23,7 +23,7 @@ Not all artifacts self-name, however. Opaque artifacts referenced by a catalog �
 
 Guidance: a publisher SHOULD set `displayName` only when the referenced artifact does not already carry its own canonical human-readable name. When the artifact does carry one, that artifact is the authoritative source and `displayName` SHOULD be omitted. When `displayName` *is* present, however, it takes precedence and is authoritative for display: a consumer SHOULD render it as given, even if it differs from a name carried by the referenced artifact — setting `displayName` is how a publisher deliberately overrides the artifact's own name.
 
-For an entry without `displayName`, a consumer SHOULD resolve a name in order: (1) the entry's `displayName` if present, (2) the referenced artifact's own canonical name (e.g. an A2A Agent Card `name` or MCP Server Card `title`) if already fetched or cached, then (3) the trailing segment of the entry's `identifier` URN. See [Resolving an Artifact's Display Name](../specification/ai-catalog.md#resolving-an-artifacts-display-name) in the specification.
+When rendering an entry, a consumer SHOULD resolve a name in order: (1) the entry's `displayName` if present, (2) the referenced artifact's own canonical name (e.g. an A2A Agent Card `name` or MCP Server Card `title`) if already fetched or cached, then (3) the trailing segment of the entry's `identifier` URN. See [Resolving an Artifact's Display Name](../specification/ai-catalog.md#resolving-an-artifacts-display-name) in the specification.
 
 This decision concerns only the Catalog Entry. `displayName` on `HostInfo` and `Publisher` is unchanged — those name the catalog host and publishing organization, which is genuinely catalog-authored metadata with no other home.
 

--- a/adr/0016-displayname-optional.md
+++ b/adr/0016-displayname-optional.md
@@ -1,0 +1,43 @@
+# ADR-0016: displayName Is Optional on a Catalog Entry
+
+## Status
+Proposed
+
+## Date
+2026-06-18 (Proposed)
+
+## Context
+A Catalog Entry is a thin pointer: it carries an `identifier`, a `mediaType`, and exactly one of `url` or `data` locating the full artifact. `displayName` (a human-readable name for the artifact) is a REQUIRED member of every Catalog Entry, and is listed among the required-at-minimum members of a Minimal Catalog (Level 1).
+
+For the card-shaped artifact types this spec calls out by media type, a human-readable name already lives inside the referenced artifact:
+
+- An **A2A Agent Card** has a REQUIRED, human-readable `name`.
+- An **MCP Server Card** carries a human-readable `title` (and a required human-readable `description`); its `name` is a reverse-DNS machine identifier.
+
+Requiring `displayName` on the entry therefore forces every catalog publisher to copy a value that already exists in the document the client is about to fetch, and to keep the two in sync indefinitely. When they drift, a consumer is left with two conflicting human-readable names and no principled way to pick.
+
+Not all artifacts self-name, however. Opaque artifacts referenced by a catalog — a raw dataset (`application/parquet`), a model blob, a skill bundle (`application/agentskill+zip`), or a nested catalog — have no embedded canonical name. For those, the entry is the only place a human-readable name can live.
+
+## Decision
+`displayName` is an **OPTIONAL** member of a Catalog Entry, not a required one, and is removed from the Minimal Catalog (Level 1) required-at-minimum set.
+
+Guidance: a publisher SHOULD set `displayName` only when the referenced artifact does not already carry its own canonical human-readable name. When the artifact does carry one, that artifact is the authoritative source and `displayName` SHOULD be omitted. When `displayName` is present and disagrees with a name carried by the referenced artifact, consumers SHOULD treat the artifact's own name as authoritative.
+
+This decision concerns only the Catalog Entry. `displayName` on `HostInfo` and `Publisher` is unchanged — those name the catalog host and publishing organization, which is genuinely catalog-authored metadata with no other home.
+
+## Rationale
+- For self-naming artifacts (A2A Agent Cards, MCP Server Cards), requiring an entry-level name guarantees permanent duplication and a standing sync burden.
+- Keeping the name authoritative at its source keeps it fresh and avoids the "two conflicting names" failure mode.
+- The entry stays a thin pointer, consistent with the catalog's role as a lightweight directory of links (ADR-0013: authoring/discovery format).
+- The field is preserved (not removed) so opaque, nameless artifacts still have a place to carry a human-readable name.
+- Mirrors the project's existing "optional, not mandatory" posture for discovery mechanics (ADR-0011).
+
+## Alternatives Considered
+- **Keep `displayName` required.** The strongest argument is browsing UX: a UI listing N entries shouldn't have to fetch N artifacts just to show names. Rejected as a permanent duplication/sync cost; the optional form still lets any publisher populate `displayName` on every entry when a self-describing list view is wanted — it just isn't forced on card-backed entries.
+- **Remove `displayName` from the entry entirely.** Rejected because opaque artifacts (datasets, model blobs, skill bundles, nested catalogs) embed no self-describing name and would be left nameless in a catalog.
+
+## Open Question
+An MCP Server Card's `title` is itself OPTIONAL. The guidance above is keyed on whether the artifact *carries a canonical name*, not on its media type: if a referenced Server Card omits `title`, the entry SHOULD keep `displayName` so the artifact is not left with only a reverse-DNS identifier and a prose description.
+
+## Meeting Reference
+Slated for discussion at the 2026-06-18 AI Catalog bi-weekly working-group call; this ADR records the proposal ahead of that discussion. Update the Status and Date (and note who raised concerns and the agreed outcome, as in ADR-0011) once the working group ratifies it.

--- a/adr/0016-displayname-optional.md
+++ b/adr/0016-displayname-optional.md
@@ -21,7 +21,9 @@ Not all artifacts self-name, however. Opaque artifacts referenced by a catalog �
 ## Decision
 `displayName` is an **OPTIONAL** member of a Catalog Entry, not a required one, and is removed from the Minimal Catalog (Level 1) required-at-minimum set.
 
-Guidance: a publisher SHOULD set `displayName` only when the referenced artifact does not already carry its own canonical human-readable name. When the artifact does carry one, that artifact is the authoritative source and `displayName` SHOULD be omitted. When `displayName` is present and disagrees with a name carried by the referenced artifact, consumers SHOULD treat the artifact's own name as authoritative.
+Guidance: a publisher SHOULD set `displayName` only when the referenced artifact does not already carry its own canonical human-readable name. When the artifact does carry one, that artifact is the authoritative source and `displayName` SHOULD be omitted. When `displayName` *is* present, however, it takes precedence and is authoritative for display: a consumer SHOULD render it as given, even if it differs from a name carried by the referenced artifact — setting `displayName` is how a publisher deliberately overrides the artifact's own name.
+
+For an entry without `displayName`, a consumer SHOULD resolve a name in order: (1) the entry's `displayName` if present, (2) the referenced artifact's own canonical name (e.g. an A2A Agent Card `name` or MCP Server Card `title`) if already fetched or cached, then (3) the trailing segment of the entry's `identifier` URN. See [Resolving an Artifact's Display Name](../specification/ai-catalog.md#resolving-an-artifacts-display-name) in the specification.
 
 This decision concerns only the Catalog Entry. `displayName` on `HostInfo` and `Publisher` is unchanged — those name the catalog host and publishing organization, which is genuinely catalog-authored metadata with no other home.
 

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -122,13 +122,11 @@ For example, a minimal catalog listing three AI artifacts:
     },
     {
       "identifier": "urn:example:mcp:weather",
-      "displayName": "Weather Service",
       "mediaType": "application/mcp-server-card+json",
       "url": "https://api.example.com/.well-known/mcp/server-card.json"
     },
     {
       "identifier": "urn:example:a2a:research",
-      "displayName": "Research Assistant",
       "mediaType": "application/a2a-agent-card+json",
       "url": "https://agents.example.com/researchAssistant"
     }
@@ -194,9 +192,6 @@ It MUST contain the following members:
   See [Multi-Version Entries](#multi-version-entries) for uniqueness
   rules when multiple versions are present.
 
-`displayName`
-: A string containing a human-readable name for the artifact.
-
 `mediaType`
 : A string containing the media type that identifies the type of the
   referenced artifact. This is the mechanism by which clients
@@ -223,6 +218,20 @@ provide the artifact content:
   is opaque to this specification.
 
 The following members are OPTIONAL:
+
+`displayName`
+: A string containing a human-readable name for the artifact.
+  This field SHOULD be set only when the referenced artifact does not
+  already carry its own canonical human-readable name — for example a
+  raw dataset (`application/parquet`), a model blob, or a skill bundle
+  (`application/agentskill+zip`), none of which embed a self-describing
+  name. When the referenced artifact does carry such a name — for
+  example the `name` field of an A2A Agent Card or the `title` field of
+  an MCP Server Card — that artifact is the authoritative source and
+  `displayName` SHOULD be omitted to avoid duplicating a value that can
+  drift out of sync. When `displayName` is present and disagrees with a
+  name carried by the referenced artifact, consumers SHOULD treat the
+  artifact's own name as authoritative.
 
 `description`
 : A string containing a short description of the artifact.
@@ -279,7 +288,6 @@ For example, a catalog listing two versions of the same agent:
   "entries": [
     {
       "identifier": "urn:acme:agent:finance",
-      "displayName": "Acme Finance Agent",
       "version": "2.1.0",
       "mediaType": "application/a2a-agent-card+json",
       "url": "https://api.acme-corp.com/agents/finance/v2.1.json",
@@ -287,7 +295,6 @@ For example, a catalog listing two versions of the same agent:
     },
     {
       "identifier": "urn:acme:agent:finance",
-      "displayName": "Acme Finance Agent",
       "version": "2.0.0",
       "mediaType": "application/a2a-agent-card+json",
       "url": "https://api.acme-corp.com/agents/finance/v2.0.json",
@@ -896,7 +903,7 @@ A conformant Minimal Catalog is a JSON document with media type
 
 - `specVersion` — the specification version string
 - `entries` — an array of Catalog Entry objects, each containing at
-  minimum `identifier`, `displayName`, `mediaType`, and exactly one of `url` or
+  minimum `identifier`, `mediaType`, and exactly one of `url` or
   `data`
 
 All other fields (`host`, `publisher`, `trustManifest`,
@@ -1300,7 +1307,6 @@ artifact types including a nested catalog packaging related artifacts:
   "entries": [
     {
       "identifier": "urn:acme:agent:finance-a2a",
-      "displayName": "Acme Finance A2A Agent",
       "version": "2.1.0",
       "mediaType": "application/a2a-agent-card+json",
       "url": "https://api.acme-corp.com/agents/finance.json",
@@ -1333,7 +1339,6 @@ artifact types including a nested catalog packaging related artifacts:
     },
     {
       "identifier": "urn:acme:server:finance-mcp",
-      "displayName": "Acme Finance MCP Server",
       "version": "1.4.0",
       "mediaType": "application/mcp-server-card+json",
       "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json",
@@ -1352,13 +1357,11 @@ artifact types including a nested catalog packaging related artifacts:
         "entries": [
           {
             "identifier": "urn:acme:agent:finance-a2a",
-            "displayName": "Finance A2A Agent",
             "mediaType": "application/a2a-agent-card+json",
             "url": "https://api.acme-corp.com/agents/finance.json"
           },
           {
             "identifier": "urn:acme:server:finance-mcp",
-            "displayName": "Finance MCP Server",
             "mediaType": "application/mcp-server-card+json",
             "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json"
           },
@@ -1407,7 +1410,6 @@ document:
   "entries": [
     {
       "identifier": "urn:acme:agent:assistant",
-      "displayName": "Acme Corporate Assistant",
       "version": "3.0.0",
       "mediaType": "application/a2a-agent-card+json",
       "url": "https://api.acme-corp.com/agents/assistant.json",
@@ -1468,13 +1470,11 @@ containing both protocol-specific entries:
     "entries": [
       {
         "identifier": "urn:acme:agent:finance:mcp",
-        "displayName": "Acme Finance MCP Server",
         "mediaType": "application/mcp-server-card+json",
         "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json"
       },
       {
         "identifier": "urn:acme:agent:finance:a2a",
-        "displayName": "Acme Finance A2A Agent",
         "mediaType": "application/a2a-agent-card+json",
         "url": "https://api.acme-corp.com/agents/finance"
       }
@@ -1734,7 +1734,7 @@ does not address.
 |:---|:---|
 | `server.json` document (whole file) | Artifact content via entry `url` or `data` |
 | `name` (reverse-DNS identifier) | Entry `identifier` (mapped to URI form) |
-| `title` | Entry `displayName` |
+| `title` | Stays in the artifact (`server.json` carries its own `title`); entry `displayName` is omitted unless the artifact lacks a name |
 | `description` | Entry `description` |
 | `version` | Entry `version` |
 | `repository` | Entry `metadata.repository` |
@@ -1772,7 +1772,6 @@ reflects the Registry format:
 ```json
 {
   "identifier": "urn:mcp:io.modelcontextprotocol.anonymous/brave-search",
-  "displayName": "Brave Search",
   "version": "1.0.2",
   "mediaType": "application/json",
   "url": "https://registry.modelcontextprotocol.io/servers/brave-search/server.json",
@@ -1835,7 +1834,6 @@ agents, skills, and other artifacts:
   "entries": [
     {
       "identifier": "urn:mcp:io.modelcontextprotocol.anonymous/brave-search",
-      "displayName": "Brave Search",
       "version": "1.0.2",
       "mediaType": "application/json",
       "url": "https://registry.modelcontextprotocol.io/servers/brave-search/server.json",
@@ -1844,7 +1842,6 @@ agents, skills, and other artifacts:
     },
     {
       "identifier": "urn:mcp:io.github.modelcontextprotocol/filesystem",
-      "displayName": "Filesystem",
       "version": "1.0.2",
       "mediaType": "application/json",
       "url": "https://registry.modelcontextprotocol.io/servers/filesystem/server.json",
@@ -1853,7 +1850,6 @@ agents, skills, and other artifacts:
     },
     {
       "identifier": "urn:mcp:io.github.example/weather-mcp",
-      "displayName": "Weather",
       "version": "0.5.0",
       "mediaType": "application/json",
       "url": "https://registry.modelcontextprotocol.io/servers/weather/server.json",
@@ -1939,7 +1935,6 @@ server can reference the Server Card as its artifact content:
 ```json
 {
   "identifier": "urn:mcp:example.com:finance-server",
-  "displayName": "Acme Finance MCP Server",
   "mediaType": "application/mcp-server+json",
   "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json",
   "description": "MCP server for financial data and trading tools",
@@ -2023,7 +2018,7 @@ plugins/
 | Marketplace `description` | Catalog `metadata.description` |
 | Marketplace `owner` | Catalog `host` (with `identifier` derived from owner) |
 | `plugins[]` array | Catalog `entries[]` array |
-| Plugin `name` | Entry `displayName` and `identifier` (derived as URN) |
+| Plugin `name` | Entry `identifier` (derived as URN); the plugin manifest carries its own name, so entry `displayName` is omitted |
 | Plugin `description` | Entry `description` |
 | Plugin `category` | Entry `tags[]` (first tag) |
 | Plugin `tags` | Entry `tags[]` (merged with category) |
@@ -2071,7 +2066,6 @@ maps to an AI Catalog where each plugin is an entry:
   "entries": [
     {
       "identifier": "urn:claude-plugin:anthropic:agent-sdk-dev",
-      "displayName": "agent-sdk-dev",
       "mediaType": "application/vnd.anthropic.claude-plugin+json",
       "url": "https://github.com/anthropics/claude-plugins-official/tree/main/plugins/agent-sdk-dev",
       "description": "Development kit for working with the Claude Agent SDK",
@@ -2086,7 +2080,6 @@ maps to an AI Catalog where each plugin is an entry:
     },
     {
       "identifier": "urn:claude-plugin:adspirer:ads-agent",
-      "displayName": "adspirer-ads-agent",
       "mediaType": "application/vnd.anthropic.claude-plugin+json",
       "url": "https://github.com/amekala/adspirer-mcp-plugin.git",
       "description": "Cross-platform ad management for Google Ads, Meta Ads, TikTok Ads, and LinkedIn Ads.",
@@ -2107,7 +2100,6 @@ maps to an AI Catalog where each plugin is an entry:
     },
     {
       "identifier": "urn:claude-plugin:aikido:security",
-      "displayName": "aikido",
       "mediaType": "application/vnd.anthropic.claude-plugin+json",
       "url": "https://github.com/AikidoSec/aikido-claude-plugin.git",
       "description": "Aikido Security scanning — SAST, secrets, and IaC vulnerability detection.",
@@ -2154,7 +2146,6 @@ contains multiple artifact types:
     "entries": [
       {
         "identifier": "urn:claude-plugin:anthropic:example-plugin:mcp",
-        "displayName": "Example Plugin MCP Server",
         "mediaType": "application/mcp-server-card+json",
         "url": "https://github.com/anthropics/claude-plugins-official/blob/main/plugins/example-plugin/server-card.json"
       },

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -229,9 +229,13 @@ The following members are OPTIONAL:
   example the `name` field of an A2A Agent Card or the `title` field of
   an MCP Server Card — that artifact is the authoritative source and
   `displayName` SHOULD be omitted to avoid duplicating a value that can
-  drift out of sync. When `displayName` is present and disagrees with a
-  name carried by the referenced artifact, consumers SHOULD treat the
-  artifact's own name as authoritative.
+  drift out of sync. When `displayName` *is* present, however, it takes
+  precedence: it is the authoritative value for display, and a consumer
+  SHOULD render it as given even when it differs from a name carried by
+  the referenced artifact. Setting `displayName` is how a publisher
+  deliberately overrides the artifact's own name. See
+  [Resolving an Artifact's Display Name](#resolving-an-artifacts-display-name)
+  for the full consumer resolution order.
 
 `description`
 : A string containing a short description of the artifact.
@@ -262,6 +266,36 @@ The following members are OPTIONAL:
 : A Trust Manifest object as defined in [Trust Manifest](#trust-manifest)
   providing verifiable identity and trust metadata for this artifact.
   See [Trust Manifest](#trust-manifest) for details.
+
+### Resolving an Artifact's Display Name
+
+Because `displayName` is OPTIONAL, a consumer rendering a catalog entry
+cannot assume it is present. To obtain a human-readable name, a consumer
+SHOULD resolve one in the following order:
+
+1. **`displayName` on the entry**, if present. A publisher-supplied
+   `displayName` always wins, even when it differs from a name carried by
+   the referenced artifact.
+2. **The referenced artifact's own canonical name**, if the consumer has
+   already fetched or cached the artifact — for example the `name` field
+   of an A2A Agent Card or the `title` field of an MCP Server Card.
+3. **The trailing segment of the entry's `identifier`** as a last
+   resort — the portion after its final `:` or `/` delimiter. For
+   example, `urn:example:mcp:weather` yields `weather` and
+   `urn:mcp:io.modelcontextprotocol.anonymous/brave-search` yields
+   `brave-search`.
+
+A consumer SHOULD NOT dereference an artifact at render time solely to
+obtain a name. A registry, directory, or other service built on top of a
+catalog SHOULD resolve the name once at ingestion — alongside any other
+derived metadata it attaches, such as relevance scores or tags — and
+cache the result, rather than fetching artifacts on the rendering path.
+
+This order also covers a referenced MCP Server Card whose `title` is
+itself absent: step 2 yields no name, so the consumer falls through to
+the `identifier` segment in step 3. A publisher MAY still set
+`displayName` on such an entry to provide a better name than the bare
+identifier segment.
 
 ## Multi-Version Entries
 

--- a/specification/examples/ai-catalog.json
+++ b/specification/examples/ai-catalog.json
@@ -8,7 +8,6 @@
   "entries": [
     {
       "identifier": "urn:example:agent-finance-001",
-      "displayName": "Acme Finance Agent",
       "mediaType": "application/a2a-agent-card+json",
       "description": "Multi-protocol finance agent.",
       "tags": [


### PR DESCRIPTION
## What this proposes

Make `displayName` **OPTIONAL** on the **Catalog Entry** rather than required — i.e. move it from the required members of a Catalog Entry ([`ai-catalog.md` §Catalog Entry](https://github.com/Agent-Card/ai-catalog/blob/main/specification/ai-catalog.md#catalog-entry)) into the OPTIONAL members, drop it from the **Minimal Catalog** (Level 1) conformance requirement, and add guidance that it SHOULD be set **only when the referenced artifact does not already carry its own canonical human-readable name**.

The intent: when an entry points at an artifact that names itself (an A2A Agent Card, an MCP Server Card), the artifact is the single source of truth and the entry shouldn't duplicate the name. When an entry points at something opaque that has *no* embedded name (a raw dataset, a model blob, a skill bundle), the entry is the only place a human-readable name can live — so the field stays available for exactly that case.

This change deliberately does **not** touch `displayName` on the **HostInfo** or **Publisher** objects — those name the catalog host and the publishing org respectively, which is genuinely catalog-authored metadata with no other home.

### Alternative considered: removing the field entirely

My first instinct was to remove `displayName` from the entry level altogether and always defer to the artifact, but I'm not suggesting it because that would mean opaque artifacts have nowhere else to put a name. [`examples/ai-catalog.json`](https://github.com/Agent-Card/ai-catalog/blob/main/specification/examples/ai-catalog.json) has an `application/parquet` dataset entry; a Parquet file, a model blob, or a skill `.zip` doesn't embed a self-describing display name the way a card does. Removing the field outright would leave those artifacts nameless in a catalog. So "optional, with guidance" is the proposal; "remove entirely" is the rejected alternative.

## Why make it optional — the duplication / drift problem

A Catalog Entry already points at the full artifact via `url` or `data`. For the card-shaped artifact types this spec calls out by media type, the human-readable name is **already present in the artifact itself**:

- **A2A Agent Card** — `name` is a **REQUIRED**, human-readable field. From the A2A protobuf spec ([`specification/a2a.proto`](https://github.com/a2aproject/A2A/blob/main/specification/a2a.proto), `message AgentCard`):
  ```proto
  // A human readable name for the agent.
  // Example: "Recipe Agent"
  string name = 1 [(google.api.field_behavior) = REQUIRED];
  ```
- **MCP Server Card** — already carries a human-readable display name. In the [Server Card schema](https://github.com/modelcontextprotocol/experimental-ext-server-card/blob/main/schema.json), `name` is a reverse-DNS machine identifier (`^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$`), while **`title`** is documented as *"Optional human-readable title or display name for the MCP server"*, and `description` (required) is human-readable too.

So for the two flagship artifact types, *requiring* `displayName` on the entry means **every catalog publisher copies a value that already exists in the document the client is about to fetch**, and then has to keep the two in sync forever. When they drift — and over time they will — a consumer has two conflicting human-readable names for the same thing and no principled way to pick. Making the field optional (and recommending omission for self-naming artifacts) keeps the name fresh and authoritative at its source, while the entry stays a thin pointer.

## What's in the diff

- **Normative:** `displayName` moved from required → OPTIONAL members, with a SHOULD-guidance paragraph (set it only when the artifact has no canonical name; omit it for self-naming cards; the artifact's own name wins on conflict). Removed from the Minimal Catalog (Level 1) required-at-minimum list.
- **Examples (all of them, for internal consistency):** card-backed entries (A2A cards, MCP Server Cards, registry `server.json`, plugin manifests) now omit `displayName`; opaque entries (the `application/parquet` dataset, `application/agentskill+zip` skill bundles) and nested `application/ai-catalog+json` entries — which have no embedded canonical name — keep it. `HostInfo`/`Publisher` `displayName` untouched. The field still exists, so the class diagram and the "logical format" vocabulary lists are unchanged.
- **Conceptual-mapping tables** (MCP registry, Claude plugins) updated so the human-readable name maps to the artifact, with entry `displayName` framed as the fallback for nameless artifacts.

## Some history (for transparency)

As far as I can reconstruct from the public record, `displayName` was **required from its first appearance** rather than as the outcome of an explicit "should this be mandatory?" debate:

- It entered the draft as `name` in commit [`0271c14`](https://github.com/Agent-Card/ai-catalog/commit/0271c14873) (2026-03-31), already under "It MUST contain the following members."
- It was renamed `name` → `displayName` in [`1e8c70c9`](https://github.com/Agent-Card/ai-catalog/commit/1e8c70c9f3611135ca5fb7002781a1dca19c8e89) per the AI Actor Naming Standard ([PR #19](https://github.com/Agent-Card/ai-catalog/pull/19)), still required, and shipped via [PR #27](https://github.com/Agent-Card/ai-catalog/pull/27).

I went looking for a written rationale for the *mandatory* status specifically — across the ADRs (0001–0013), issues, and discussions — and couldn't find one. The closest articulations of the field's *purpose* are [PR #19](https://github.com/Agent-Card/ai-catalog/pull/19) (*"a human-readable name used for discovery in UIs … not required to be unique"*) and [ADR 0013](https://github.com/Agent-Card/ai-catalog/blob/main/adr/0013-authoring-vs-distribution-formats.md) framing the catalog as *"the authoring and discovery format — a human-readable JSON document."* I might simply be missing the discussion where requiring it was decided — **if there's prior context I've overlooked, please point me to it**, since it likely bears directly on the tradeoff.

## Counter-argument to landing this

The strongest argument I can construct *for keeping it required* is **browsing UX**: a UI that renders a list of N artifacts shouldn't have to fetch N separate cards just to show names, so requiring `displayName` on the entry makes the catalog self-describing for a cheap list view.

However, that's a steep trade-off for a permanent duplication/sync cost; one we'd like to avoid making on the MCP side. I'm not sure I'm convinced that UIs of AI Catalogs will be a major use case of AI Catalog (please correct me if you foresee otherwise, would love to understand the use case), and the optional form still lets a publisher populate `displayName` on every entry if they want the self-describing list view. It just doesn't force the card-backed entries to carry a redundant copy.

If there's a use case beyond browsing that makes the field load-bearing enough to mandate, would love to understand.
