### PR TITLE
chore: add Tadas Antanavicius (PulseMCP) to TSC members

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,7 +7,7 @@ The AI Catalog project is governed by the Technical Steering Committee. The init
 | Google | Junjie Bu | https://github.com/mindpower |
 | Microsoft | Darrel Miller | https://github.com/darrelmiller |
 | Anthropic | David Soria Parra | https://github.com/dsp-ant |
-| MCP Core maintainer nominee | TBD |  |
+| PulseMCP | Tadas Antanavicius | https://github.com/tadasant |
 ## Mission and Scope of the Project
 
 1. The mission of the Project is to enable discovery of AI services and related artifacts. The Project includes collaborative development of the following components:


### PR DESCRIPTION
Adds Tadas Antanavicius from PulseMCP to the TSC members table in GOVERNANCE.md.