### PR TITLE
chore: update specStatus to Official and fix markdown formatting

### DIFF
--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -203,10 +203,10 @@ It MUST contain the following members:
   determine what kind of AI artifact the entry represents. Well-known
   values include (but are not limited to):
 
-  - `application/ai-catalog+json` — a nested AI Catalog
-  - `application/a2a-agent-card+json` — an A2A Agent Card
-  - `application/mcp-server-card+json` — an MCP Server Card
-  - Any other media type defined by a protocol specification (e.g.,
+- `application/ai-catalog+json` — a nested AI Catalog
+- `application/a2a-agent-card+json` — an A2A Agent Card
+- `application/mcp-server-card+json` — an MCP Server Card
+- Any other media type defined by a protocol specification (e.g.,
     `application/agentskill+zip` for skill definitions)
 
 A Catalog Entry MUST contain exactly one of the following members to

--- a/tools/build_spec.py
+++ b/tools/build_spec.py
@@ -19,7 +19,7 @@ DEFAULT_CONFIG = REPO_ROOT / "specification/respec-config.json"
 
 
 DEFAULT_RESPEC_CONFIG = {
-    "specStatus": "unofficial",
+    "specStatus": "Official",
     "editors": [],
     "latestVersion": None,
     "noRecTrack": True,


### PR DESCRIPTION
## Summary

- Set `specStatus` from `"unofficial"` to `"Official"` in `tools/build_spec.py`
- Fix list indentation and missing newline in `specification/ai-catalog.md`