### PR TITLE
chore: preserve CNAME for ai-catalog.io on gh-pages publish

### DIFF
--- a/.github/workflows/publish-spec.yml
+++ b/.github/workflows/publish-spec.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           python3 tools/update_gh_pages.py root \
             --source-dir .site/root \
+            --cname ai-catalog.io \
             --remote-url "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" \
             --commit-message "Publish specification site from main"
 
@@ -158,7 +159,7 @@ jobs:
       - name: Comment preview URL on pull request
         env:
           GH_TOKEN: ${{ github.token }}
-          PREVIEW_URL: https://agent-card.github.io/ai-catalog/pr/${{ github.event.pull_request.number }}/
+          PREVIEW_URL: https://ai-catalog.io/pr/${{ github.event.pull_request.number }}/
         run: |
           marker='<!-- ai-catalog-preview-url -->'
           body=$(cat <<EOF

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Common AI Catalog and Registry Standard
 
-[![Specification](https://img.shields.io/badge/GitHub%20Pages-AI%20Catalog-222222?logo=githubpages&logoColor=white)](https://agent-card.github.io/ai-catalog/) [![Build](https://github.com/Agent-Card/ai-catalog/actions/workflows/publish-spec.yml/badge.svg?branch=main)](https://github.com/Agent-Card/ai-catalog/actions/workflows/publish-spec.yml)
+[![Specification](https://img.shields.io/badge/Specification-AI%20Catalog-222222?logo=githubpages&logoColor=white)](https://ai-catalog.io/) [![Build](https://github.com/Agent-Card/ai-catalog/actions/workflows/publish-spec.yml/badge.svg?branch=main)](https://github.com/Agent-Card/ai-catalog/actions/workflows/publish-spec.yml)
 
 ## tl;dr
 
@@ -12,9 +12,9 @@ Contact us via GitHub Discussions, [Issues](https://github.com/Agent-Card/ai-cat
 
 The AI Catalog specification is built from `specification/ai-catalog.md` and published to GitHub Pages by the workflow in `.github/workflows/publish-spec.yml`.
 
-Published site: [agent-card.github.io/ai-catalog](https://agent-card.github.io/ai-catalog/)
+Published site: [ai-catalog.io](https://ai-catalog.io/)
 
-Pushes to the `main` branch update the canonical published site. Same-repo pull requests publish rendered preview pages under `https://agent-card.github.io/ai-catalog/pr/<number>/`, including a rendered diff preview against the PR base branch. The workflow also keeps a pull request comment updated with the live preview URL while the PR remains open.
+Pushes to the `main` branch update the canonical published site. Same-repo pull requests publish rendered preview pages under `https://ai-catalog.io/pr/<number>/`, including a rendered diff preview against the PR base branch. The workflow also keeps a pull request comment updated with the live preview URL while the PR remains open.
 
 GitHub Pages for the repository should be configured to serve from the `gh-pages` branch at the repository root.
 

--- a/specification/respec-config.json
+++ b/specification/respec-config.json
@@ -1,7 +1,7 @@
 {
   "title": "AI Catalog",
   "shortName": "ai-catalog",
-  "edDraftURI": "https://agent-card.github.io/ai-catalog/",
+  "edDraftURI": "https://ai-catalog.io/",
   "abstract": "This document defines the AI Catalog, a JSON format for discovering heterogeneous AI artifacts such as MCP servers, A2A agents, Claude Code plugins, datasets, and model cards. Each catalog entry declares the artifact's type via a media type and references or inlines the native artifact metadata, enabling a single discovery mechanism across protocols and platforms. The specification defines three conformance levels — Minimal, Discoverable, and Trusted — allowing implementations to start with a simple list of entries and progressively add host identity, well-known URI discovery, and verifiable trust metadata as needed. An optional Trust Manifest extension provides identity binding, compliance attestations, provenance tracking, and cryptographic signatures without wrapping or modifying the artifact's native format. Informative appendices describe mappings to OCI distribution registries, the MCP Registry server.json format, and the Claude Code Plugins marketplace.",
   "appendixHeaders": ["Data Model", "CDDL", "Example", "Mapping", "Acknowledgment", "Appendix", "IANA"],
   "localBiblio": {

--- a/tools/update_gh_pages.py
+++ b/tools/update_gh_pages.py
@@ -51,6 +51,10 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Apply the changes locally without committing or pushing",
     )
+    parser.add_argument(
+        "--cname",
+        help="Custom domain to write into the CNAME file at the root of gh-pages (root mode only)",
+    )
     return parser.parse_args()
 
 
@@ -106,10 +110,12 @@ def clear_root(checkout_dir: Path, preserve_names: set[str]) -> None:
         remove_path(child)
 
 
-def stage_root_publish(checkout_dir: Path, source_dir: Path) -> None:
+def stage_root_publish(checkout_dir: Path, source_dir: Path, cname: str | None = None) -> None:
     clear_root(checkout_dir, {"pr"})
     copy_tree_contents(source_dir, checkout_dir)
     (checkout_dir / ".nojekyll").touch()
+    if cname:
+        (checkout_dir / "CNAME").write_text(cname + "\n", encoding="utf-8")
 
 
 def stage_preview_publish(checkout_dir: Path, source_dir: Path, pr_number: int) -> None:
@@ -183,7 +189,7 @@ def prepare_checkout(
 
 def apply_mode(args: argparse.Namespace, checkout_dir: Path) -> None:
     if args.mode == "root":
-        stage_root_publish(checkout_dir, args.source_dir.resolve())
+        stage_root_publish(checkout_dir, args.source_dir.resolve(), getattr(args, "cname", None))
         return
     if args.mode == "preview":
         stage_preview_publish(checkout_dir, args.source_dir.resolve(), args.pr_number)


### PR DESCRIPTION
Fixes the custom domain being wiped on every publish. Adds `--cname ai-catalog.io` to the deploy script and updates all remaining old URL references.