### PR TITLE
fix(spec): make displayName optional in CatalogEntry CDDL (align with ADR-0016)

### DIFF
--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -1280,7 +1280,7 @@ HostInfo = {
 
 CatalogEntry = {
   identifier: text,
-  displayName: text,
+  ? displayName: text,
   type: text,
   (url: text // data: any),
   ? version: text,


### PR DESCRIPTION
The normative CDDL schema (§CDDL Schema, `CatalogEntry`) still lists `displayName: text` as **required**, but **ADR-0016 (#39)** made `displayName` **optional** — and the prose (§Catalog Entry, §"Resolving an Artifact's Display Name") plus the **Level-1 (Minimal) conformance** definition already treat it as optional. The CDDL is the lone holdout, so it currently contradicts them.

One-line fix:

```
- displayName: text,
+ ? displayName: text,
```

Without it, a CDDL-only validator rejects otherwise-conformant entries that omit `displayName` — e.g. when the referenced artifact self-names (an A2A Agent Card / MCP Server Card), which ADR-0016 explicitly recommends. Publisher's `displayName` is left required, unchanged.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*