### PR TITLE
fix(spec): repair broken intra-document anchor links

### DIFF
--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -255,7 +255,7 @@ The following members are OPTIONAL:
   SHOULD render it as given even when it differs from a name carried by
   the referenced artifact. Setting `displayName` is how a publisher
   deliberately overrides the artifact's own name. See
-  [Resolving an Artifact's Display Name](#resolving-an-artifacts-display-name)
+  [Resolving an Artifact's Display Name](#resolving-an-artifact-s-display-name)
   for the full consumer resolution order.
 
 `description`
@@ -381,7 +381,7 @@ The following members are OPTIONAL:
 : A string providing a type hint for the publisher identifier (e.g.,
   "did", "dns").
 
-# Trust Manifest {#trust-manifest}
+# Trust Manifest
 
 The Trust Manifest is an OPTIONAL companion to catalog entries and
 host objects. It is a JSON object that provides verifiable identity,
@@ -783,7 +783,7 @@ depth to prevent circular references. A depth limit of 4 is
 RECOMMENDED. Implementations MAY support deeper nesting but SHOULD
 document their limit.
 
-# Metadata Extensibility {#metadata-extensibility}
+# Metadata Extensibility
 
 The `metadata` property appears on the AI Catalog top-level object,
 on Catalog Entry objects, and on Trust Manifest objects. It provides
@@ -818,7 +818,7 @@ Metadata values MAY be any valid JSON type (string, number, boolean,
 array, object, null). Consumers that do not recognize a metadata key
 SHOULD ignore it.
 
-# Version Handling {#version-handling}
+# Version Handling
 
 The `specVersion` field identifies which version of this specification
 a catalog conforms to. This section defines how producers and consumers


### PR DESCRIPTION
## Summary

Several intra-document anchor links on the rendered spec site (https://ai-catalog.io/) did not navigate anywhere. The reported one was **"Resolving an Artifact's Display Name"** (in the `displayName` field description under Catalog Entry), but scanning the whole document surfaced more of the same class.

## Root cause

The site is built by a **custom script** (`tools/build_spec.py`) that derives each section's `id` by running its own `slugify()` over the **full heading title text** (lowercase → replace runs of non-`[a-z0-9]` with `-` → strip → dedupe by order). It does **not** support the Pandoc/kramdown `{#id}` attribute syntax — headings are extracted by a regex *before* the markdown converter runs, so `attr_list` never sees them. Two consequences:

1. **Headings authored as `# X {#x}`** — `Trust Manifest`, `Metadata Extensibility`, `Version Handling` — had the `{#x}` rendered as **literal visible text** and slugified into a **doubled** id (e.g. `trust-manifest-trust-manifest`, `metadata-extensibility-metadata-extensibility`, `version-handling-version-handling`). So:
   - `#metadata-extensibility` → matched nothing (broken).
   - `#version-handling` → matched nothing (broken).
   - `#trust-manifest` → *appeared* to work, but all four references resolved to the **CDDL "Trust Manifest"** appendix (which slugified cleanly to `trust-manifest`), **not** the Trust Manifest definition (§5) they were meant to point at.
2. **`Resolving an Artifact's Display Name`** — the apostrophe slugifies to `-s-`, producing `resolving-an-artifact-s-display-name`, but the link dropped the apostrophe (`resolving-an-artifacts-display-name`, GitHub-style), so it matched nothing.

Adding explicit `{#...}` ids (the intuitive fix) would **not** work under this build — it would just add more literal-text garbage and doubled slugs. The correct, convention-consistent fix is to work with what `slugify(title)` actually produces.

## Fix (minimal, anchors only — 4 lines)

- Removed the non-functional `{#...}` from the three `#`-level headings so their slugs derive cleanly from the titles (`trust-manifest`, `metadata-extensibility`, `version-handling`). This also removes the visible brace text and makes `#trust-manifest` resolve to the Trust Manifest **definition** (§5) instead of the CDDL appendix.
- Pointed the display-name link at the slug the build generates: `#resolving-an-artifact-s-display-name` (the heading keeps its apostrophe for correct English, so the href is the thing to fix here).

No prose or structure changed beyond these four lines.

## Verification

- [x] **Reproduced the canonical build locally** (`uv run --python 3.12 --locked python tools/build_spec.py …`, same invocation as the `publish-root` CI job) and ran an intra-doc link checker over the generated HTML. **Before:** 3 broken links (`#metadata-extensibility`, `#version-handling`, `#resolving-an-artifacts-display-name`). **After:** **0 broken** of 22 intra-doc links (15 unique fragments).
- [x] **Confirmed the true id mismatch in a real browser** on the live site: the "Resolving an Artifact's Display Name" section renders with id `resolving-an-artifact-s-display-name` (not the linked `resolving-an-artifacts-display-name`), and the `{#...}` headings rendered doubled ids with literal brace text. ReSpec's own linter reported `Broken local reference found in document` with 3 elements before the fix; it is gone on the head-revision preview after the fix.
- [x] **Full-document scan for the same bug class:** checked every `](#…)` link against the built ids; the anchors above were the only broken/mis-targeted ones, and all now resolve. No other apostrophe/special-char anchors were missed.
- [x] **`#trust-manifest` regression check:** nothing links to the CDDL appendix's id (now demoted to `trust-manifest-2`), so redirecting `#trust-manifest` to the definition section breaks nothing — it only corrects a previously-wrong target. Bounded id-set diff: exactly the 3 polluted `X-X` slugs removed, exactly the 3 clean slugs added; all other referenced fragments unchanged.
- [x] **PR-preview click-through proof.** On the rendered head-revision preview (https://ai-catalog.io/pr/61/head/index.html), clicking the "Resolving an Artifact's Display Name" link navigates to `…#resolving-an-artifact-s-display-name` and scrolls the section to the top of the viewport. Screenshot below (note the URL fragment; the left ToC also shows "Trust Manifest" / "Metadata Extensibility" now render without the `{#…}` brace text):

  ![anchor resolves to the correct section on the PR preview](https://storage.googleapis.com/remote-filesystem-tadas/screenshots/ai-catalog/pr61-anchor-fixed.png)

- [x] **Independent fresh-eyes review** of the diff and build mechanics: **APPROVE** — no regressions, no missed anchors, fix approach confirmed correct.
- [x] **CI green** (`Publish Specification` → `build` + `publish-pr-preview`).
