### PR TITLE
docs: reconcile mkdocs site with spec + ADRs (MCP drift)

### DIFF
--- a/docs/examples/minimal-catalog.md
+++ b/docs/examples/minimal-catalog.md
@@ -15,7 +15,7 @@ The simplest valid AI Catalog — just a `specVersion` and a list of entries. Th
     {
       "identifier": "urn:air:example.com:mcp:weather",
       "type": "application/mcp-server-card+json",
-      "url": "https://api.example.com/.well-known/mcp/server-card.json"
+      "url": "https://api.example.com/mcp/server-card"
     },
     {
       "identifier": "urn:air:example.com:a2a:research",

--- a/docs/examples/multi-protocol-agent.md
+++ b/docs/examples/multi-protocol-agent.md
@@ -26,7 +26,7 @@ An agent that supports both MCP and A2A protocols can be represented as a single
           {
             "identifier": "urn:air:acme-corp.com:mcp:finance",
             "type": "application/mcp-server-card+json",
-            "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json"
+            "url": "https://api.acme-corp.com/mcp/server-card"
           },
           {
             "identifier": "urn:air:acme-corp.com:a2a:finance",
@@ -41,7 +41,6 @@ An agent that supports both MCP and A2A protocols can be represented as a single
           {
             "type": "SOC2-Type2",
             "uri": "https://trust.acme-corp.com/reports/soc2.pdf",
-            "mediaType": "application/pdf",
             "digest": "sha256:a1b2c3d4e5f6"
           }
         ]

--- a/docs/examples/nested-catalogs.md
+++ b/docs/examples/nested-catalogs.md
@@ -63,7 +63,7 @@ The Finance team owns and hosts `finance.json`. It can be updated independently 
     {
       "identifier": "urn:air:acme-corp.com:mcp:finance",
       "type": "application/mcp-server-card+json",
-      "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json",
+      "url": "https://api.acme-corp.com/mcp/server-card",
       "tags": ["finance", "mcp"]
     },
     {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ Create a file named `ai-catalog.json` with the following content:
     {
       "identifier": "urn:air:myorg.com:mcp:my-server",
       "type": "application/mcp-server-card+json",
-      "url": "https://api.myorg.com/.well-known/mcp/server-card.json"
+      "url": "https://api.myorg.com/mcp/server-card"
     }
   ]
 }

--- a/docs/guides/adding-trust.md
+++ b/docs/guides/adding-trust.md
@@ -68,7 +68,7 @@ Trust builds on the three conformance levels:
 A Trust Manifest is an object on a Catalog Entry (or Host Info object) with one required field:
 
 `identity`
-:   A globally unique URI that serves as the primary subject identifier for this artifact — typically a DID, SPIFFE ID, or URL. When the Trust Manifest is on a Catalog Entry, the identity's **authority (trust domain) MUST align with the publisher domain segment of the entry's `identifier`** (e.g., an entry `urn:air:acme-corp.com:a2a:finance` requires an identity anchored to `acme-corp.com`). Consumers MUST reject a Trust Manifest whose identity domain does not align. This binding ensures trust claims are cryptographically bound to the authorized publisher.
+:   A globally unique URI that identifies this artifact. **Its trust domain must align with the publisher domain in the containing entry's `identifier`.** This binding ties trust claims to the authorized publisher.
 
 All other fields are optional:
 

--- a/docs/guides/adding-trust.md
+++ b/docs/guides/adding-trust.md
@@ -68,7 +68,7 @@ Trust builds on the three conformance levels:
 A Trust Manifest is an object on a Catalog Entry (or Host Info object) with one required field:
 
 `identity`
-:   A globally unique URI that identifies this artifact. **Must match the containing entry's `identifier`.** This binding ensures trust claims are unambiguously associated with the right artifact.
+:   A globally unique URI that serves as the primary subject identifier for this artifact — typically a DID, SPIFFE ID, or URL. When the Trust Manifest is on a Catalog Entry, the identity's **authority (trust domain) MUST align with the publisher domain segment of the entry's `identifier`** (e.g., an entry `urn:air:acme-corp.com:a2a:finance` requires an identity anchored to `acme-corp.com`). Consumers MUST reject a Trust Manifest whose identity domain does not align. This binding ensures trust claims are cryptographically bound to the authorized publisher.
 
 All other fields are optional:
 
@@ -95,7 +95,6 @@ The simplest trust step is asserting publisher identity. Use an attestation of t
     {
       "type": "publisher-identity",
       "uri": "https://trust.acme-corp.com/certs/publisher.jwt",
-      "mediaType": "application/jwt",
       "description": "Verifies did:web:acme-corp.com as publisher"
     }
   ]
@@ -111,14 +110,12 @@ For regulated environments, add compliance evidence:
   {
     "type": "SOC2-Type2",
     "uri": "https://trust.acme-corp.com/reports/soc2.pdf",
-    "mediaType": "application/pdf",
     "digest": "sha256:a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890",
     "description": "SOC 2 Type 2 report, valid through 2026"
   },
   {
     "type": "ISO27001",
-    "uri": "https://trust.acme-corp.com/certs/iso27001.pdf",
-    "mediaType": "application/pdf"
+    "uri": "https://trust.acme-corp.com/certs/iso27001.pdf"
   }
 ]
 ```
@@ -214,13 +211,11 @@ A Trust Manifest with identity, compliance attestation, provenance, and signatur
       {
         "type": "publisher-identity",
         "uri": "https://trust.acme-corp.com/certs/publisher.jwt",
-        "mediaType": "application/jwt",
         "description": "Verifies did:web:acme-corp.com as publisher"
       },
       {
         "type": "SOC2-Type2",
         "uri": "https://trust.acme-corp.com/reports/soc2.pdf",
-        "mediaType": "application/pdf",
         "digest": "sha256:a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890"
       }
     ],

--- a/docs/guides/creating-a-catalog.md
+++ b/docs/guides/creating-a-catalog.md
@@ -64,7 +64,7 @@ Every entry must have these three things:
 {
   "identifier": "urn:air:acme-corp.com:mcp:weather",
   "type": "application/mcp-server-card+json",
-  "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json"
+  "url": "https://api.acme-corp.com/mcp/server-card"
 }
 ```
 
@@ -82,11 +82,13 @@ Every entry must have these three things:
 | Artifact | `type` value |
 |---|---|
 | AI Catalog (nested) | `application/ai-catalog+json` |
+| Agent Card (generic) | `application/agent-card+json` |
 | A2A Agent Card | `application/a2a-agent-card+json` |
 | MCP Server Card | `application/mcp-server-card+json` |
-| Agent Skill (ZIP bundle) | `application/agent-skills+zip` |
-| Agent Skill (Markdown) | `application/agent-skills+md` |
 | Agent Skill metadata (JSON) | `application/agent-skills+json` |
+| Agent Skill (Markdown) | `application/agent-skills+md` |
+| Agent Skill (ZIP bundle) | `application/agent-skills+zip` |
+| Agent Skill (gzipped tarball) | `application/agent-skills+gzip` |
 | Dataset | `application/parquet`, `text/csv`, or appropriate type |
 
 This list is not exhaustive — AI Catalog accepts any string as a `type` value. The spec is intentionally artifact-agnostic.
@@ -246,7 +248,7 @@ Metadata keys should use reverse-DNS prefixes for vendor-specific keys (`com.acm
       "description": "Real-time weather data and forecasts.",
       "tags": ["weather", "data"],
       "version": "1.2.0",
-      "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json",
+      "url": "https://api.acme-corp.com/mcp/server-card",
       "updatedAt": "2026-04-01T09:00:00Z",
       "publisher": {
         "identifier": "did:web:acme-corp.com",

--- a/docs/guides/organizing-catalogs.md
+++ b/docs/guides/organizing-catalogs.md
@@ -107,7 +107,7 @@ Bundle related artifacts together using the `data` field to embed the child cata
       {
         "identifier": "urn:air:acme-corp.com:mcp:finance",
         "type": "application/mcp-server-card+json",
-        "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json"
+        "url": "https://api.acme-corp.com/mcp/server-card"
       },
       {
         "identifier": "urn:air:acme-corp.com:data:market-2026q1",
@@ -143,7 +143,7 @@ An agent that supports both MCP and A2A can be represented as one logical entry 
       {
         "identifier": "urn:air:acme-corp.com:mcp:finance",
         "type": "application/mcp-server-card+json",
-        "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json"
+        "url": "https://api.acme-corp.com/mcp/server-card"
       },
       {
         "identifier": "urn:air:acme-corp.com:a2a:finance",

--- a/docs/guides/serving-your-catalog.md
+++ b/docs/guides/serving-your-catalog.md
@@ -52,7 +52,7 @@ The mapping works as follows:
 | AI Catalog (logical) | OCI (physical) |
 |---|---|
 | AI Catalog document | OCI Image Index with `artifactType: "application/ai-catalog+json"` |
-| Catalog Entry | OCI Image Manifest with `artifactType` set to the entry's `mediaType` |
+| Catalog Entry | OCI Image Manifest with `artifactType` set to the entry's `type` |
 | Entry artifact content | Manifest `layers[0]` blob |
 | Entry metadata | Manifest `config` blob and/or `annotations` |
 | Nested catalog entry | Nested OCI Image Index |
@@ -74,9 +74,9 @@ OCI distribution provides Layer 3 trust: all content is addressed by cryptograph
 
 For the full OCI mapping specification including the Image Index structure and Referrers API usage, refer to the [Full Specification](../specification.md).
 
-## MCP Registry mapping
+## MCP servers
 
-If you operate an MCP Registry, your `server.json` entries map naturally to AI Catalog entries. The MCP Registry can serve an AI Catalog view of its contents, where each MCP server becomes a catalog entry with `mediaType: "application/mcp-server-card+json"`.
+Remote (HTTP-connectable) MCP servers map to AI Catalog entries by referencing each server's [MCP Server Card](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127). Each MCP server becomes a catalog entry with `type: "application/mcp-server-card+json"` whose `url` points to the server's Server Card. A domain — or a registry — that hosts several MCP servers can publish them all as a single AI Catalog.
 
 This enables cross-protocol discovery: a client that understands AI Catalog can discover MCP servers alongside A2A agents, datasets, and other artifact types from a single endpoint.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ AI Catalog solves this with a simple, typed JSON format that indexes any kind of
     {
       "identifier": "urn:air:acme-corp.com:mcp:weather",
       "type": "application/mcp-server-card+json",
-      "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json"
+      "url": "https://api.acme-corp.com/mcp/server-card"
     },
     {
       "identifier": "urn:air:acme-corp.com:a2a:research",

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -15,7 +15,7 @@ The specification covers:
 - **Version handling** — compatibility rules for producers and consumers
 - **Security considerations** — trust layers, catalog poisoning, typosquatting, embedded content safety
 - **CDDL schema** — formal machine-readable schema
-- **Mappings** — how AI Catalog maps to OCI Distribution, MCP Registry `server.json`, and Claude Code Plugins
+- **Mappings** — how AI Catalog maps to OCI Distribution, MCP servers (via MCP Server Cards), and Claude Code Plugins
 
 ## Relationship to these docs
 


### PR DESCRIPTION
## What this does

The mkdocs documentation site under `docs/` is meant to **mirror and simplify the specification** (`specification/ai-catalog.md` + the ADRs in `adr/`). Several pages had drifted from the current spec — mostly around **MCP** — describing an older model. This PR brings the docs back into line with the spec. **No spec or ADR files are changed; only `docs/`.** Where the docs and the spec disagreed, the docs were treated as wrong and corrected to match the spec.

## Inconsistencies found & fixed

| # | Doc location(s) | Was (drifted) | Now (matches spec) | Authority |
|---|---|---|---|---|
| 1 | `index.md`, `getting-started.md`, `guides/creating-a-catalog.md` (×2), `guides/organizing-catalogs.md` (×2), `examples/minimal-catalog.md`, `examples/multi-protocol-agent.md`, `examples/nested-catalogs.md` — **9 URLs** | MCP Server Card served at `…/.well-known/mcp/server-card.json` | `…/mcp/server-card` (the form the spec examples use) | **ADR-0011** — the `.well-known` convention is for the **AI Catalog**, not the Server Card; spec examples never put the card under `.well-known` |
| 2 | `guides/adding-trust.md` (×5), `examples/multi-protocol-agent.md` (×1) | Attestation objects carried a `"mediaType": …` field | field removed | **ADR-0014** — `mediaType` was removed from the Attestation object; it has only `type`/`uri` (required) + optional `digest`/`size`/`description` (spec "Attestation Object") |
| 3 | `guides/serving-your-catalog.md` (OCI table) | OCI Image Manifest `artifactType` set to the entry's **`mediaType`** | …set to the entry's **`type`** | **ADR-0014** (`mediaType` → `type`); matches the spec's OCI mapping table verbatim. `artifactType` itself is a real OCI field and is kept. |
| 4 | `guides/serving-your-catalog.md` (§ heading + body) | "**MCP Registry mapping**" — "your `server.json` entries map naturally… each MCP server becomes an entry with `mediaType: application/mcp-server-card+json`" | "**MCP servers**" — servers map by referencing each server's **MCP Server Card** (`type: application/mcp-server-card+json`, `url` → the card) | Spec appendix "**Mapping to MCP Servers**" (Server-Card–based, not `server.json`-based) |
| 5 | `specification.md` (mappings list) | "…maps to OCI Distribution, **MCP Registry `server.json`**, and Claude Code Plugins" | "…OCI Distribution, **MCP servers (via MCP Server Cards)**, and Claude Code Plugins" | Same spec appendix rename |
| 6 | `guides/adding-trust.md` (`identity` field) | "`identity` … **Must match the containing entry's `identifier`.**" (asserted exact-string match) | its **trust domain must align with the publisher domain** in the entry's `identifier` (a one-line correction, kept in the docs' simple style) | Spec Trust Manifest "**Identity**" section (domain-alignment, not exact match) |
| 7 | `guides/creating-a-catalog.md` (known-`type` table) | table omitted two spec-recognized known types | added `application/agent-card+json` and `application/agent-skills+gzip` | Spec "known types" list under the entry `type` field |

## Not changed (deliberately)

- **AI Catalog served at `/.well-known/ai-catalog.json`** — still correct and kept; ADR-0011 only makes it OPTIONAL (a SHOULD-register convention), and the docs already present link-relation discovery as the primary mechanism with well-known as fallback.
- `artifactType` in the OCI-mapping context — a legitimate OCI field, retained.
- The `type`-is-a-media-type framing — consistent with the spec's own Design Goal ("declare its artifact type using a media type"), so left as-is.