### PR TITLE
fix: clean up mediaType-to-type rename fallout (ADR 0014/0015)

### DIFF
--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -1152,7 +1152,6 @@ classDiagram
     class Attestation {
         type string
         uri string
-        type string
         digest string
     }
     class ProvenanceLink {
@@ -1324,7 +1323,6 @@ TrustSchema = {
 Attestation = {
   type: text,
   uri: text,
-  type: text,
   ? digest: text,
   ? size: uint,
   ? description: text
@@ -1668,11 +1666,11 @@ authored by hand:
 ```json
 {
   "schemaVersion": 2,
-  "type": "application/vnd.oci.image.index.v1+json",
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "artifactType": "application/ai-catalog+json",
   "manifests": [
     {
-      "type": "application/vnd.oci.image.manifest.v1+json",
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
       "digest": "sha256:aaa111...",
       "size": 1024,
       "artifactType": "application/a2a-agent-card+json",
@@ -1682,7 +1680,7 @@ authored by hand:
       }
     },
     {
-      "type": "application/vnd.oci.image.manifest.v1+json",
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
       "digest": "sha256:bbb222...",
       "size": 512,
       "artifactType": "application/mcp-server-card+json",

--- a/specification/examples/ai-catalog.json
+++ b/specification/examples/ai-catalog.json
@@ -2,13 +2,13 @@
   "specVersion": "1.0",
   "host": {
     "displayName": "Acme Services Inc.",
-    "identifier": "did:example:org-acme-corp",
+    "identifier": "did:web:acme-corp.com",
     "documentationUrl": "https://docs.acme-corp.com/agents"
   },
   "entries": [
     {
-      "identifier": "urn:example:agent-finance-001",
-      "mediaType": "application/a2a-agent-card+json",
+      "identifier": "urn:air:acme-corp.com:agent:finance",
+      "type": "application/a2a-agent-card+json",
       "description": "Multi-protocol finance agent.",
       "tags": [
         "finance",
@@ -18,9 +18,9 @@
       "updatedAt": "2026-02-22T16:30:00Z"
     },
     {
-      "identifier": "urn:example:data:market-dataset-2026q1",
+      "identifier": "urn:air:acme-corp.com:data:market-2026q1",
       "displayName": "Market Dataset Q1 2026",
-      "mediaType": "application/parquet",
+      "type": "application/parquet",
       "description": "Artifact-focused card for training and evaluation.",
       "tags": [
         "dataset",


### PR DESCRIPTION
Fixes #66

The `mediaType` -> `type` rename (ADR 0014) was applied mechanically in a few places it should not have been, and skipped one place it should have reached. This PR cleans up all three:

## 1. Duplicate `type` member in the Attestation schema

ADR 0014 removed `mediaType` from the Attestation object, but it was renamed to `type` instead of deleted, leaving the CDDL with a duplicate map key (invalid CDDL). The mermaid diagram in "Data Model Overview" had the same duplicate. Both now declare `type` once.

## 2. OCI Image Index example restored to `mediaType`

The example in "Mapping to OCI Distribution > OCI Image Index Example" used `"type"` on the index and manifest descriptors. The OCI image spec requires the field name `mediaType`, so the example was not valid OCI. The rename does not apply to third-party OCI JSON; restored `mediaType` in the three descriptor positions (`artifactType` fields untouched).

## 3. `specification/examples/ai-catalog.json` migrated

The standalone example file still used `mediaType`, so its entries were missing the required `type` member and did not validate against the spec's own CDDL. Migrated to `type`, and updated the identifiers from the pre-ADR-0015 `urn:example:...` style to the standardized `urn:air:{publisher}:{namespace}:{name}` form (with the host identifier aligned to the `did:web:` style used in the spec's other examples).

## Verification

- `uv run --locked python tools/build_spec.py specification/ai-catalog.md ... --config specification/respec-config.json` builds cleanly
- `specification/examples/ai-catalog.json` parses as valid JSON and now conforms to the CatalogEntry CDDL (has `identifier`, `type`, and exactly one of `url`/`data`)
