### PR TITLE
chore: add implementations page to documentation

### DIFF
--- a/docs/implementations.md
+++ b/docs/implementations.md
@@ -1,0 +1,8 @@
+# Implementations
+
+This page lists various implementations and testbeds for the AI Catalog specification.
+
+- [spec-works/ai-catalog](https://github.com/spec-works/ai-catalog) (C#, Python)
+- [ai-catalog-go-sdk](https://github.com/agntcy/ai-catalog-go-sdk/) (Go)
+- [ai-catalog-rust](https://github.com/agntcy/ai-catalog-rust) (Rust)
+- [AI Catalog](https://ai-catalog.outshift.io/) (testbed service)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,15 +78,18 @@ extra:
 
 nav:
   - Home: index.md
+  - Specification: specification.md
   - Getting Started: getting-started.md
   - Guides:
       - Creating a Catalog: guides/creating-a-catalog.md
-      - Serving Your Catalog: guides/serving-your-catalog.md
-      - Consuming Catalogs: guides/consuming-catalogs.md
       - Organizing Catalogs: guides/organizing-catalogs.md
+      - Consuming Catalogs: guides/consuming-catalogs.md
+      - Serving Your Catalog: guides/serving-your-catalog.md
       - Adding Trust: guides/adding-trust.md
   - Examples:
       - Minimal Catalog: examples/minimal-catalog.md
       - Multi-Protocol Agent: examples/multi-protocol-agent.md
       - Nested Catalogs: examples/nested-catalogs.md
-  - Full Specification: specification.md
+  - Implementations: implementations.md
+
+


### PR DESCRIPTION
This PR adds an 'Implementations' page to the documentation to list various implementations and testbeds for the AI Catalog specification.