### PR TITLE
Resolve #58: Add ADR-0017 and migrate to namespace extensions map

### DIFF
--- a/adr/0017-ard-loose-coupling.md
+++ b/adr/0017-ard-loose-coupling.md
@@ -1,0 +1,31 @@
+# ADR-0017: Loose Coupling of ARD and AI-Catalog
+
+## Status
+Accepted
+
+## Date
+2026-07-02 (Discussed), 2026-07-09 (Agreed)
+
+**Participants:** Darrel Miller, David Soria Parra, Jeffrey Damick, Jonathan Hefner, Junjie Bu, Luca Muscariello, Mariano Gonzalez, Martin Ristov, Pamela Dingle, Ramanathan Guha, Ramiz Polić, Sam Betts, Tadas Antanavicius
+
+## Context
+The AI-Catalog specification defines a lightweight format for agentic artifact discovery. Recently, a significant debate emerged regarding how to handle extensibility and vendor-specific fields. A proposal was made (Issue #58) to use a JSON-LD inspired `@context` mechanism to map prefix-based fields (e.g. `okf:type`) to absolute IRIs, replacing the nested `metadata` / `extensions` approach.
+
+While ARD (Agentic Resource Discovery) spec group strongly advocated for `@context` to support rich, federated metadata returned from various domains (such as TechSoup and SEC databases, which already heavily utilize semantic web standards like schema.org), there was strong opposition from AI-Catalog TSC members. 
+
+The primary concerns from the AI-Catalog perspective were:
+1. **Scope:** AI-Catalog entries are meant to act as "least common denominator" pointers/leaves, not as rich data envelopes.
+2. **Complexity:** Introducing `@context` and dynamic keys could complicate rigid bindings (e.g., gRPC protojson) and introduce perceived JSON-LD processing baggage.
+
+After extensive discussions in the July 2 and July 9, 2026 working group meetings, the team concluded that the requirements of the two projects are fundamentally different. ARD requires the ability to aggregate rich, namespaced descriptions of resources directly in the discovery payload, while AI-Catalog requires strict, minimal schema definitions.
+
+## Decision
+The ARD (Agentic Resource Discovery) specification will be **loosely coupled** with the AI-Catalog specification. 
+
+AI-Catalog will proceed without native `@context` support and will instead rely on simpler mechanisms (such as an `extensions` array/object) for minimal extensions. ARD will evolve its data model independently to fully support the rich, namespaced metadata and semantic schemas required for comprehensive, web-scale agentic resource discovery.
+
+## Rationale
+- **Preserves Core Visions:** Allows AI-Catalog to remain a lightweight, strictly-typed "thin pointer" registry format.
+- **Unblocks Innovation:** Frees ARD to adopt flexible semantic descriptors (JSON-LD / `@context`, schema.org) necessary for advanced discovery and LLM context building without forcing these complex requirements onto all AI-Catalog implementations.
+- **Development Velocity:** Prevents the specifications from blocking each other due to conflicting data model requirements, allowing both groups to iterate rapidly.
+

--- a/adr/0017-ard-loose-coupling.md
+++ b/adr/0017-ard-loose-coupling.md
@@ -20,9 +20,7 @@ The primary concerns from the AI-Catalog perspective were:
 After extensive discussions in the July 2 and July 9, 2026 working group meetings, the team concluded that the requirements of the two projects are fundamentally different. ARD requires the ability to aggregate rich, namespaced descriptions of resources directly in the discovery payload, while AI-Catalog requires strict, minimal schema definitions.
 
 ## Decision
-The ARD (Agentic Resource Discovery) specification will be **loosely coupled** with the AI-Catalog specification. 
-
-AI-Catalog will proceed without native `@context` support and will instead rely on simpler mechanisms (such as an `extensions` array/object) for minimal extensions. ARD will evolve its data model independently to fully support the rich, namespaced metadata and semantic schemas required for comprehensive, web-scale agentic resource discovery.
+AI-Catalog will proceed without native `@context` support and will instead rely on simpler mechanisms (such as an `extensions` map) for minimal extensions. ARD will evolve its data model independently to fully support the rich, namespaced metadata and semantic schemas required for comprehensive, web-scale agentic resource discovery.
 
 ## Rationale
 - **Preserves Core Visions:** Allows AI-Catalog to remain a lightweight, strictly-typed "thin pointer" registry format.

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -816,13 +816,16 @@ For example, a catalog entry with `extensions` representing metadata and a custo
       "type": "text/vnd.okf+markdown",
       "tags": ["finance", "treasury"],
       "extensions": {
-        "metadata": {
+        "https://ai-catalog.org/extensions/metadata": {
           "location": "US-West",
           "environment": "staging",
           "version-compatible": [">=1.0.0"]
         },
-        "okf": {
-          "@context": "https://openknowledgeformat.org/ns#",
+        "https://openknowledgeformat.org/ns#": {
+          "@context": {
+            "us-gaap": "https://xbrl.fasb.org/us-gaap/",
+            "ifrs": "https://xbrl.ifrs.org/taxonomy/"
+          },
           "type": "Financial Dataset",
           "taxonomy": "us-gaap",
           "conformsTo": ["us-gaap:Revenue", "ifrs:Revenue"]
@@ -839,7 +842,7 @@ While publishers are free to create custom extensions, this specification
 defines a set of "Official" known types for commonly requested schemas:
 
 1. **Metadata** (`https://ai-catalog.org/extensions/metadata`)
-   - Used to store generic, schemaless key-value pairs (replacing the legacy metadata field).
+   - Used to store generic, schemaless key-value pairs.
 
 As custom extensions become highly popular, the AI-Catalog TSC may promote
 them to Official Known Types or core standard fields in future specification versions.

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -141,7 +141,7 @@ The following members are OPTIONAL:
   operator of this catalog.
 
 `extensions`
-: An array of Extension objects containing custom, vendor-specific, or
+: A JSON object (map) containing custom, vendor-specific, or
   non-standard fields. See [Extensions](#extensions) for definitions and
   official extension types.
 
@@ -275,7 +275,7 @@ The following members are OPTIONAL:
   when this entry was last modified.
 
 `extensions`
-: An array of Extension objects containing custom data.
+: A JSON object (map) containing custom data.
 
 `publisher`
 : A Publisher object as defined in [Publisher Object](#publisher-object)
@@ -456,7 +456,7 @@ The following members are OPTIONAL:
   of the trust metadata independent of the artifact.
 
 `extensions`
-: An array of Extension objects for extending trust metadata.
+: A JSON object (map) for extending trust metadata.
 
 For example, a Trust Manifest with identity, attestations, and
 provenance:
@@ -791,10 +791,10 @@ properties.
 
 ## Format and Key Naming
 
-The `extensions` field is an array of objects. Each object MUST contain
-a `type` string and a `data` object.
+The `extensions` field is a JSON object (map). Each key in the object MUST
+represent the extension type (namespace), and the corresponding value contains the extension data.
 
-To avoid collisions between independent publishers, the `type` field MUST
+To avoid collisions between independent publishers, the keys MUST
 be a valid URL or a reverse-DNS string:
 
 - **Reverse-DNS prefix** for vendor-specific extensions:
@@ -802,8 +802,36 @@ be a valid URL or a reverse-DNS string:
 - **URL prefix** for publicly accessible extension schemas:
   `https://cisco.com/extensions/security-scan`.
 
-Consumers that do not recognize an extension `type` MUST ignore it without
+Consumers that do not recognize an extension key MUST ignore it without
 throwing an error.
+
+For example, a catalog entry with `extensions` representing metadata and a custom schema:
+
+```json
+{
+  "specVersion": "1.0",
+  "entries": [
+    {
+      "identifier": "urn:air:treasury.gov:okf:fiscaldata",
+      "type": "text/vnd.okf+markdown",
+      "tags": ["finance", "treasury"],
+      "extensions": {
+        "metadata": {
+          "location": "US-West",
+          "environment": "staging",
+          "version-compatible": [">=1.0.0"]
+        },
+        "okf": {
+          "@context": "https://openknowledgeformat.org/ns#",
+          "type": "Financial Dataset",
+          "taxonomy": "us-gaap",
+          "conformsTo": ["us-gaap:Revenue", "ifrs:Revenue"]
+        }
+      }
+    }
+  ]
+}
+```
 
 ## Official Extensions
 
@@ -812,8 +840,6 @@ defines a set of "Official" known types for commonly requested schemas:
 
 1. **Metadata** (`https://ai-catalog.org/extensions/metadata`)
    - Used to store generic, schemaless key-value pairs (replacing the legacy metadata field).
-2. **SBOM** (`https://ai-catalog.org/extensions/sbom`)
-   - Used to embed or link to a Software Bill of Materials for the catalog entry.
 
 As custom extensions become highly popular, the AI-Catalog TSC may promote
 them to Official Known Types or core standard fields in future specification versions.
@@ -1267,12 +1293,7 @@ AICatalog = {
   specVersion: text,
   ? host: HostInfo,
   entries: [* CatalogEntry],
-  ? extensions: [* Extension]
-}
-
-Extension = {
-  type: text,
-  data: any
+  ? extensions: { * text => any }
 }
 
 HostInfo = {
@@ -1294,7 +1315,7 @@ CatalogEntry = {
   ? publisher: Publisher,
   ? trustManifest: TrustManifest,
   ? updatedAt: tdate,
-  ? extensions: [* Extension]
+  ? extensions: { * text => any }
 }
 
 Publisher = {
@@ -1316,7 +1337,7 @@ TrustManifest = {
   ? privacyPolicyUrl: text,
   ? termsOfServiceUrl: text,
   ? signature: text,
-  ? extensions: [* Extension]
+  ? extensions: { * text => any }
 }
 
 TrustSchema = {

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -140,10 +140,10 @@ The following members are OPTIONAL:
 : A Host Info object as defined in [Host Info](#host-info) identifying the
   operator of this catalog.
 
-`metadata`
-: An open map of string keys to arbitrary values for custom or
-  non-standard metadata. See [Metadata Extensibility](#metadata-extensibility)
-  for key naming conventions.
+`extensions`
+: An array of Extension objects containing custom, vendor-specific, or
+  non-standard fields. See [Extensions](#extensions) for definitions and
+  official extension types.
 
 ## Host Info
 
@@ -274,8 +274,8 @@ The following members are OPTIONAL:
 : A string containing an ISO 8601 [[RFC3339]] timestamp indicating
   when this entry was last modified.
 
-`metadata`
-: An open map of string keys to arbitrary values for custom data.
+`extensions`
+: An array of Extension objects containing custom data.
 
 `publisher`
 : A Publisher object as defined in [Publisher Object](#publisher-object)
@@ -455,9 +455,8 @@ The following members are OPTIONAL:
   over the Trust Manifest content. This enables integrity verification
   of the trust metadata independent of the artifact.
 
-`metadata`
-: An open map of string keys to arbitrary values for extending trust
-  metadata.
+`extensions`
+: An array of Extension objects for extending trust metadata.
 
 For example, a Trust Manifest with identity, attestations, and
 provenance:
@@ -783,40 +782,41 @@ depth to prevent circular references. A depth limit of 4 is
 RECOMMENDED. Implementations MAY support deeper nesting but SHOULD
 document their limit.
 
-# Metadata Extensibility
+# Extensions
 
-The `metadata` property appears on the AI Catalog top-level object,
+The `extensions` property appears on the AI Catalog top-level object,
 on Catalog Entry objects, and on Trust Manifest objects. It provides
 a single, well-defined extension point for custom or vendor-specific
 properties.
 
-## Key Naming
+## Format and Key Naming
 
-Metadata keys MUST be non-empty strings. To avoid collisions between
-independent publishers, the following conventions are RECOMMENDED:
+The `extensions` field is an array of objects. Each object MUST contain
+a `type` string and a `data` object.
 
-- **Reverse-DNS prefix** for vendor-specific keys:
+To avoid collisions between independent publishers, the `type` field MUST
+be a valid URL or a reverse-DNS string:
+
+- **Reverse-DNS prefix** for vendor-specific extensions:
   `com.example.confidenceScore`, `io.acme.deploymentRegion`.
-- **Short, unqualified names** for keys the publisher considers
-  broadly useful and unlikely to conflict: `repository`, `homepage`,
-  `license`.
-- **Avoid keys that duplicate** defined catalog fields (`displayName`,
-  `description`, `tags`, `version`). Consumers MAY ignore metadata
-  entries that shadow standard fields.
+- **URL prefix** for publicly accessible extension schemas:
+  `https://cisco.com/extensions/security-scan`.
 
-## Reserved Keys
+Consumers that do not recognize an extension `type` MUST ignore it without
+throwing an error.
 
-No metadata keys are reserved by this specification. Future
-specification versions MAY promote commonly used metadata keys into
-standard fields. When this occurs, the metadata key SHOULD be
-retained for backward compatibility and the standard field takes
-precedence.
+## Official Extensions
 
-## Value Types
+While publishers are free to create custom extensions, this specification
+defines a set of "Official" known types for commonly requested schemas:
 
-Metadata values MAY be any valid JSON type (string, number, boolean,
-array, object, null). Consumers that do not recognize a metadata key
-SHOULD ignore it.
+1. **Metadata** (`https://ai-catalog.org/extensions/metadata`)
+   - Used to store generic, schemaless key-value pairs (replacing the legacy metadata field).
+2. **SBOM** (`https://ai-catalog.org/extensions/sbom`)
+   - Used to embed or link to a Software Bill of Materials for the catalog entry.
+
+As custom extensions become highly popular, the AI-Catalog TSC may promote
+them to Official Known Types or core standard fields in future specification versions.
 
 # Version Handling
 
@@ -1267,7 +1267,12 @@ AICatalog = {
   specVersion: text,
   ? host: HostInfo,
   entries: [* CatalogEntry],
-  ? metadata: { * text => any }
+  ? extensions: [* Extension]
+}
+
+Extension = {
+  type: text,
+  data: any
 }
 
 HostInfo = {
@@ -1289,7 +1294,7 @@ CatalogEntry = {
   ? publisher: Publisher,
   ? trustManifest: TrustManifest,
   ? updatedAt: tdate,
-  ? metadata: { * text => any }
+  ? extensions: [* Extension]
 }
 
 Publisher = {
@@ -1311,7 +1316,7 @@ TrustManifest = {
   ? privacyPolicyUrl: text,
   ? termsOfServiceUrl: text,
   ? signature: text,
-  ? metadata: { * text => any }
+  ? extensions: [* Extension]
 }
 
 TrustSchema = {


### PR DESCRIPTION
### Summary
This PR formally resolves Issue #58 (Proposal for JSON-LD `@context` Namespaces) by implementing the consensus reached during the July 2 and July 9 Working Group meetings and also comments on that issue.
 
To preserve the AI-Catalog's minimalist parser and avoid the complexity of JSON-LD graph resolution, the TSC agreed to reject the `@context` proposal. Instead, we are adopting a **loosely coupled architecture** with the Agentic Resource Discovery (ARD) specification and replacing the legacy `metadata` property with a strict `extensions` array.

### Changes Included
1. **Added `ADR-0017`**: Documents the decision to loosely couple ARD and AI-Catalog, preserving AI-Catalog as a strictly-typed "publishing format" while allowing ARD to evolve independently as a rich "discovery format."
2. **Updated `ai-catalog.md`**: 
   - Removed the legacy `metadata` property from the Catalog Entry, Trust Manifest, and root schemas.
   - Introduced the `extensions` array mechanism.
   - Rewrote the Extensibility section to enforce reverse-DNS/URL keys for extension boundaries.

### Motivation
This architecture allows AI-Catalog to remain a lightweight, fast "thin pointer," while freeing downstream aggregators (like ARD) to build the complex semantic envelopes they need for federated discovery without forcing those requirements into the base protocol.

Closes #58
