### PR TITLE
fix: state the nesting depth requirement at a single strength

### DIFF
--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -1035,7 +1035,7 @@ as advisory, not authoritative.
 
 ## Nested Catalog Depth and Circular References
 
-Clients processing nested catalogs MUST enforce a maximum recursion
+Clients processing nested catalogs SHOULD enforce a maximum recursion
 depth to prevent denial-of-service attacks via deeply nested or
 circular catalog references. A maximum depth of 4 is RECOMMENDED.
 


### PR DESCRIPTION
Fixes #68.

The nesting depth requirement appeared at two strength levels: Organizing Catalogs said clients SHOULD impose a maximum depth, while Security Considerations said they MUST. ADR 0001 records the decision as SHOULD/RECOMMENDED, "to allow flexibility for edge cases while establishing a clear norm".

This softens the Security Considerations sentence to SHOULD so both spec sections match the recorded decision. If the group later decides DoS protection warrants a hard MUST here, that should go through an ADR 0001 update and change both sections together.