### PR TITLE
feat(spec): add Lifecycle official extension (resolves #65)

### DIFF
--- a/adr/0023-lifecycle-metadata-extension.md
+++ b/adr/0023-lifecycle-metadata-extension.md
@@ -1,0 +1,112 @@
+# ADR-0023: Lifecycle Metadata as an Official Extension
+
+## Status
+Accepted
+
+## Date
+2026-08-06
+
+## Context
+[Issue #65](https://github.com/Agent-Card/ai-catalog/issues/65)
+observes that the specification has no way to communicate an artifact's
+software-lifecycle state at discovery time. An entry carries `version`
+(which revision this is) and `updatedAt` (when the entry last changed),
+but nothing that expresses *where that revision sits in its lifecycle*:
+whether it is a preview, generally available, deprecated with a scheduled
+end-of-life, or already retired — nor how a consumer should move off it.
+
+Agents evolve. A v1 agent is superseded by a breaking v2; an endpoint is
+scheduled for shutdown; a successor is published with a migration guide.
+Without lifecycle metadata at discovery time a consumer cannot distinguish
+a current artifact from a deprecated one, cannot learn an end-of-life date
+before committing to an integration, and cannot discover the recommended
+replacement. The core entry schema, which is intentionally closed (see
+[ADR-0012](0012-extensibility-via-metadata.md)), has no place to express
+this, and there is no interoperable convention for it today.
+
+## Decision
+Lifecycle metadata is defined as an **official extension**, registered at
+the extension key `https://ai-catalog.org/extensions/lifecycle`, and
+carried in the entry's `extensions` map. It is **not** added as a native
+`lifecycle` field on the entry.
+
+The extension value is a JSON object with these OPTIONAL members:
+
+- `status` (string) — the lifecycle state; open text, with RECOMMENDED
+  values `preview`, `active`, `deprecated`, and `retired`. Every
+  recommended value denotes a version a consumer can actually reach: a
+  catalog entry exists because the artifact is discoverable, so a
+  not-yet-released ("planned") state is deliberately excluded — an
+  unreleased version has no consumable endpoint to list.
+- `releaseDate` (string) — ISO 8601 date/date-time the version was
+  released, distinct from the entry's `updatedAt`.
+- `deprecated` (object) — deprecation detail, present when `status` is
+  `deprecated` or `retired`. It carries:
+  - `replacedBy` (string) — the `identifier` of the successor artifact,
+    subject to the same naming rule as a Catalog Entry's `identifier`
+    (`urn:air` HIGHLY RECOMMENDED, and MUST be used for open or federated
+    systems).
+  - `deprecationDate` (string) — ISO 8601 date/date-time of deprecation.
+  - `endOfLifeDate` (string) — ISO 8601 date/date-time after which the
+    version is retired.
+  - `breakingChanges` (array of strings) — human-readable breaking-change
+    descriptions.
+  - `migrationGuide` (string) — URL to migration documentation.
+
+Lifecycle metadata describes the artifact **version** identified by the
+entry, not the logical artifact as a whole: within a multi-version listing
+(see the specification's Multi-Version Entries), a v1 entry MAY be
+`deprecated` while the v2 entry is `active`. A consumer that does not
+understand the key MUST ignore it; a consumer that does understand it MAY
+filter or rank entries by lifecycle state (e.g. exclude `retired`, warn on
+`deprecated`, prefer the `replacedBy` successor) and MAY still choose a
+deprecated artifact deliberately. All identifiers use the `urn:air` format
+mandated by [ADR-0015](0015-agent-identifier-naming.md).
+
+`status` is intentionally open text rather than a closed enum, consistent
+with how the specification treats `type` and `identifier`. Because it is
+open text, a consumer MUST NOT reject an entry for an unrecognized status,
+but it also MUST NOT silently discard the value and treat the artifact as
+unqualified — that fails open, since a value such as `sunset` may signal a
+retirement the consumer would then miss. A consumer SHOULD interpret an
+unrecognized value against the recommended states (an agent consumer can
+do so semantically) and, when it cannot, treat the artifact conservatively
+rather than assume it is `active`. This preserves the spec's open-text
+extensibility while making unrecognized values fail safe rather than fail
+open.
+
+## Rationale
+- Keeps the core entry schema closed and stable, consistent with the
+  closed-core philosophy of
+  [ADR-0012](0012-extensibility-via-metadata.md); a not-yet-universal
+  need does not force a change to the core.
+- Consumers that do not recognize the key ignore it safely and treat the
+  entry as any other, guaranteed by the existing `extensions` rule.
+- The extension can evolve independently without requiring a major version
+  bump of the specification.
+- Aligns with the precedent already set by the Metadata official extension
+  (`https://ai-catalog.org/extensions/metadata`).
+
+## Alternatives Considered
+- **Native `lifecycle` field on the entry** (as the original issue
+  proposed) — Rejected. It bloats the closed core for a need that is not
+  universal and reopens the schema evolution problem ADR-0012 was written
+  to avoid.
+- **Overloading `version`/`updatedAt` with a status convention** —
+  Rejected. Those fields have defined, distinct semantics; encoding
+  lifecycle state into them would be ambiguous and non-interoperable.
+- **Freeform vendor metadata** — Rejected. Ad-hoc, per-vendor keys give no
+  interoperability, so no consumer could filter deprecated artifacts or
+  discover successors deterministically across producers.
+
+## Consequences
+- Deprecation and retirement become discoverable and actionable before a
+  consumer commits to an integration; migration paths are advertised at
+  discovery time.
+- The metadata is advisory. It is unsigned unless carried in a Trust
+  Manifest's `extensions`, and MUST NOT be treated as a security or
+  support guarantee on its own; the dates and successor reference are
+  producer assertions a consumer needing assurance corroborates out of
+  band.
+- The official extensions registry gains one entry:
+  `https://ai-catalog.org/extensions/lifecycle`.

--- a/docs/examples/lifecycle-metadata.md
+++ b/docs/examples/lifecycle-metadata.md
@@ -1,0 +1,183 @@
+# Example: Lifecycle Metadata
+
+Artifacts evolve. A v1 agent is superseded by a breaking v2, an endpoint is
+scheduled for shutdown, and a successor is published with a migration guide.
+An entry's `version` and `updatedAt` tell you *which* revision this is and
+*when the entry changed* — but not whether that revision is a preview,
+generally available, deprecated with a scheduled end-of-life, or already
+retired. The [Lifecycle official extension](../specification.md) enriches an
+entry with that software-lifecycle state, so a consumer can filter deprecated
+or retired artifacts at discovery, plan around a known end-of-life date, and
+follow a producer-supplied migration path to a successor.
+
+## The extension
+
+The extension key (namespace) is:
+
+```
+https://ai-catalog.org/extensions/lifecycle
+```
+
+It lives inside an entry's `extensions` map. Its value describes the lifecycle
+state of the **artifact version** the entry identifies — so within a
+multi-version listing, a v1 entry can be `deprecated` while the v2 entry is
+`active`.
+
+!!! note "Lifecycle is per-version"
+    Lifecycle metadata describes the version identified by the entry, not the
+    logical artifact as a whole. When a catalog lists several versions of the
+    same `identifier`, each versioned entry may carry its own Lifecycle
+    extension.
+
+## Full example
+
+A deprecated v1 agent, superseded by a v2, with a scheduled end-of-life:
+
+```json
+{
+  "identifier": "urn:air:acme.com:finance:invoice-processor",
+  "version": "1.0.0",
+  "type": "application/a2a-agent-card+json",
+  "url": "https://api.acme.com/agents/invoice/v1",
+  "tags": ["finance", "a2a"],
+  "extensions": {
+    "https://ai-catalog.org/extensions/lifecycle": {
+      "status": "deprecated",
+      "releaseDate": "2025-03-15",
+      "deprecated": {
+        "replacedBy": "urn:air:acme.com:finance:invoice-processor-v2",
+        "deprecationDate": "2026-09-01",
+        "endOfLifeDate": "2027-01-01",
+        "breakingChanges": [
+          "Authentication changed from API key to OAuth2",
+          "Response schema now uses ISO 8601 dates"
+        ],
+        "migrationGuide": "https://docs.acme.com/invoice-v2-migration"
+      }
+    }
+  }
+}
+```
+
+The successor entry carries its own lifecycle status:
+
+```json
+{
+  "identifier": "urn:air:acme.com:finance:invoice-processor-v2",
+  "version": "2.0.0",
+  "type": "application/a2a-agent-card+json",
+  "url": "https://api.acme.com/agents/invoice/v2",
+  "tags": ["finance", "a2a"],
+  "extensions": {
+    "https://ai-catalog.org/extensions/lifecycle": {
+      "status": "active",
+      "releaseDate": "2026-06-01"
+    }
+  }
+}
+```
+
+## Extension fields
+
+The extension value supports these fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | string | Optional | Lifecycle state. Recommended values: `preview`, `active`, `deprecated`, `retired` — each denotes a version a consumer can actually reach (a not-yet-released "planned" state is intentionally excluded) |
+| `releaseDate` | string | Optional | ISO 8601 date/date-time this version was released (distinct from the entry's `updatedAt`) |
+| `deprecated` | object | Optional | Deprecation detail (below); present when `status` is `deprecated` or `retired` |
+
+The `deprecated` object supports:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `replacedBy` | string | Optional | `identifier` of the successor artifact, following the same naming rule as a Catalog Entry `identifier` (`urn:air` highly recommended; required for open or federated systems) |
+| `deprecationDate` | string | Optional | ISO 8601 date/date-time the version became (or becomes) deprecated |
+| `endOfLifeDate` | string | Optional | ISO 8601 date/date-time after which the version is retired |
+| `breakingChanges` | string[] | Optional | Human-readable descriptions of breaking changes to account for when migrating |
+| `migrationGuide` | string | Optional | URL to migration documentation |
+
+## Filtering and migrating at discovery
+
+A consumer that understands the extension can read `status` to decide how to
+treat an entry — hiding or de-ranking `retired` and `deprecated` artifacts,
+warning an operator, and following `replacedBy` to the successor.
+
+Because `status` is open text, its recommended values are not exhaustive. A
+consumer may not reject an entry just because the status is unrecognized. A 
+value like `sunset` signals a retirement that failing open would miss. An 
+agent can do this semantically, and when it can't interpret confidently it 
+should apply its own policy on treating the artifact conservatively or assuming `active`:
+
+```python
+from datetime import date
+
+LIFECYCLE_KEY = "https://ai-catalog.org/extensions/lifecycle"
+RECOMMENDED_STATUSES = {"preview", "active", "deprecated", "retired"}
+
+def lifecycle(entry):
+    return entry.get("extensions", {}).get(LIFECYCLE_KEY)
+
+def normalize_status(raw):
+    """Map an open-text status onto a recommended state, or None if unclear.
+
+    A rule table handles common synonyms; an agent consumer can replace this
+    with semantic interpretation (e.g. an LLM classifying the raw value).
+    """
+    if raw is None or raw in RECOMMENDED_STATUSES:
+        return raw
+    synonyms = {
+        "sunset": "deprecated", "end-of-support": "deprecated",
+        "obsolete": "deprecated", "eol": "retired", "end-of-life": "retired",
+        "ga": "active", "generally-available": "active", "stable": "active",
+        "beta": "preview", "alpha": "preview", "rc": "preview",
+    }
+    return synonyms.get(str(raw).strip().lower())
+
+def is_selectable(entry, allow_deprecated=False):
+    """Whether an entry should be offered at discovery time."""
+    lc = lifecycle(entry)
+    if not lc:
+        return True  # no lifecycle info — treat as any other entry
+
+    status = normalize_status(lc.get("status"))
+    if status == "retired":
+        return False
+    if status == "deprecated" and not allow_deprecated:
+        return False
+    if lc.get("status") and status is None:
+        return allow_deprecated  # uninterpretable: fail safe, don't assume active
+    return True
+
+def successor_id(entry):
+    """The identifier a deprecated entry recommends migrating to, if any."""
+    lc = lifecycle(entry) or {}
+    return (lc.get("deprecated") or {}).get("replacedBy")
+```
+
+A consumer may still choose a deprecated artifact deliberately — for a
+short-lived task that finishes well before the `endOfLifeDate`, the deprecated
+version may be the pragmatic choice:
+
+```python
+def usable_until_eol(entry, deadline):
+    """A deprecated entry is fine for work that completes before its EOL."""
+    lc = lifecycle(entry) or {}
+    eol = (lc.get("deprecated") or {}).get("endOfLifeDate")
+    if not eol:
+        return True
+    return deadline < date.fromisoformat(eol[:10])
+```
+
+!!! warning "Lifecycle metadata is not a support guarantee"
+    The dates and the `replacedBy` reference are producer assertions, not
+    signed claims. A consumer that needs a supported-until guarantee
+    corroborates them out of band, not via this extension. A consumer that
+    does not understand the extension key ignores it and treats the entry as
+    any other.
+
+## Related
+
+- [Full Specification](../specification.md)
+- [Creating a Catalog](../guides/creating-a-catalog.md#the-lifecycle-extension)
+- [Consuming Catalogs](../guides/consuming-catalogs.md#filtering-by-lifecycle-status)

--- a/docs/guides/consuming-catalogs.md
+++ b/docs/guides/consuming-catalogs.md
@@ -171,6 +171,75 @@ def latest_entries(entries):
     return list(by_id.values())
 ```
 
+## Filtering by lifecycle status
+
+An entry may carry the [Lifecycle extension](../examples/lifecycle-metadata.md)
+in its `extensions` map, declaring whether the artifact version is a
+pre-release (`preview`), generally available (`active`), `deprecated`, or
+`retired`. A consumer that understands the extension can filter deprecated or
+retired artifacts at discovery and follow the recommended successor:
+
+```python
+LIFECYCLE_KEY = "https://ai-catalog.org/extensions/lifecycle"
+
+RECOMMENDED_STATUSES = {"preview", "active", "deprecated", "retired"}
+
+def normalize_status(raw):
+    """Map a status value to a recommended state.
+
+    `status` is open text, so a producer may emit a value outside the
+    recommended set. Interpret it rather than discard it — an agent can do
+    this semantically (e.g. an LLM mapping "sunset" -> "deprecated"). Return
+    None only when the value can't be interpreted with confidence.
+    """
+    if raw is None or raw in RECOMMENDED_STATUSES:
+        return raw
+    synonyms = {
+        "sunset": "deprecated", "end-of-support": "deprecated",
+        "obsolete": "deprecated", "eol": "retired", "end-of-life": "retired",
+        "ga": "active", "generally-available": "active", "stable": "active",
+        "beta": "preview", "alpha": "preview", "rc": "preview",
+    }
+    return synonyms.get(str(raw).strip().lower())  # None if uninterpretable
+
+def is_selectable(entry, allow_deprecated=False):
+    lc = entry.get("extensions", {}).get(LIFECYCLE_KEY)
+    if not lc:
+        return True  # no lifecycle info — treat as any other entry
+
+    status = normalize_status(lc.get("status"))
+    if status == "retired":
+        return False
+    if status == "deprecated" and not allow_deprecated:
+        return False
+    if lc.get("status") and status is None:
+        # Declared but uninterpretable: fail safe, don't assume "active".
+        # Surface the raw value and keep it out of long-lived commitments.
+        return allow_deprecated
+    return True
+
+def successor_id(entry):
+    """The identifier a deprecated entry recommends migrating to, if any."""
+    lc = entry.get("extensions", {}).get(LIFECYCLE_KEY) or {}
+    return (lc.get("deprecated") or {}).get("replacedBy")
+```
+
+- If you **don't** understand the extension key, ignore it and treat the entry
+  as any other.
+- `status` is open text, so its recommended values are not exhaustive. Never
+  reject an entry *just* because its status is unrecognized — but don't
+  silently discard the value either, or you fail open: a value like `sunset`
+  may signal a retirement you'd then miss.
+- Instead, **interpret** an unrecognized status against the recommended states.
+  An agent consumer can do this semantically rather than with a fixed synonym
+  table. When you can't interpret it confidently, surface the raw value and
+  treat the artifact conservatively rather than assuming it is `active`.
+- You **may** still select a deprecated artifact deliberately — for a
+  short-lived task that completes before its `endOfLifeDate`, for example.
+- The dates and `replacedBy` reference are producer assertions, not signed
+  claims. Corroborate them out of band when you need a supported-until
+  guarantee.
+
 ## TypeScript example
 
 ```typescript

--- a/docs/guides/creating-a-catalog.md
+++ b/docs/guides/creating-a-catalog.md
@@ -231,6 +231,59 @@ Both the top-level catalog object and individual entries support a `metadata` fi
 
 Metadata keys should use reverse-DNS prefixes for vendor-specific keys (`com.acme.*`), or short unqualified names for broadly useful keys (`license`, `homepage`). Avoid shadowing standard fields like `displayName` or `tags`. Clients that don't recognize a key should ignore it.
 
+## The Lifecycle extension {#the-lifecycle-extension}
+
+When an artifact version is deprecated, scheduled for retirement, or superseded
+by a successor, advertise that at discovery time with the **Lifecycle** official
+extension. It carries the version's lifecycle `status`, its release date, and —
+when deprecated — the successor, timeline, breaking changes, and migration
+guide, so consumers can filter deprecated artifacts and plan migrations.
+
+Official extensions live in the entry's `extensions` map, keyed by their
+namespace URL. The Lifecycle extension uses:
+
+```
+https://ai-catalog.org/extensions/lifecycle
+```
+
+The extension describes the **version** the entry identifies, so within a
+[multi-version listing](#multi-version-entries) each versioned entry can carry
+its own status — a deprecated v1 alongside an active v2:
+
+```json
+{
+  "identifier": "urn:air:acme-corp.com:finance:invoice-processor",
+  "version": "1.0.0",
+  "type": "application/a2a-agent-card+json",
+  "url": "https://api.acme-corp.com/agents/invoice/v1",
+  "extensions": {
+    "https://ai-catalog.org/extensions/lifecycle": {
+      "status": "deprecated",
+      "releaseDate": "2025-03-15",
+      "deprecated": {
+        "replacedBy": "urn:air:acme-corp.com:finance:invoice-processor-v2",
+        "deprecationDate": "2026-09-01",
+        "endOfLifeDate": "2027-01-01",
+        "breakingChanges": [
+          "Authentication changed from API key to OAuth2"
+        ],
+        "migrationGuide": "https://docs.acme-corp.com/invoice-v2-migration"
+      }
+    }
+  }
+}
+```
+
+Recommended `status` values are `preview`, `active`, `deprecated`, and
+`retired` — each names a version a consumer can actually reach (there is no
+"planned" state, since an unreleased version has no endpoint to list). Include
+the `deprecated` object when the status is `deprecated` or `retired`, and
+populate `replacedBy` or `migrationGuide` (or both) so a consumer can act on
+the deprecation.
+
+See [Lifecycle Metadata](../examples/lifecycle-metadata.md) for the full example
+and field reference.
+
 ## Complete example
 
 ```json

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - Minimal Catalog: examples/minimal-catalog.md
       - Multi-Protocol Agent: examples/multi-protocol-agent.md
       - Nested Catalogs: examples/nested-catalogs.md
+      - Lifecycle Metadata: examples/lifecycle-metadata.md
   - Implementations: implementations.md
 
 

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -1155,9 +1155,179 @@ defines a set of "Official" known types for commonly requested schemas:
 
 1. **Metadata** (`https://ai-catalog.org/extensions/metadata`)
    - Used to store generic, schemaless key-value pairs.
+2. **Lifecycle** (`https://ai-catalog.org/extensions/lifecycle`)
+   - Declares the software-lifecycle state of the artifact version
+     identified by the entry — release, deprecation timeline, breaking
+     changes, and recommended successor — so consumers can filter
+     deprecated or retired artifacts and plan migrations at discovery time.
 
 As custom extensions become highly popular, the AI-Catalog TSC may promote
 them to Official Known Types or core standard fields in future specification versions.
+
+## Lifecycle Metadata Extension
+
+Official extension key: `https://ai-catalog.org/extensions/lifecycle`
+
+An entry's `version` and `updatedAt` record *which* revision of an
+artifact this is and *when* the entry last changed, but they say nothing
+about *where that revision sits in its lifecycle* — whether it is a
+preview, generally available, deprecated with a scheduled end-of-life, or
+already retired — nor how a consumer should move off it. Agents evolve: a
+v1 agent is superseded by a breaking v2, an endpoint is scheduled for
+shutdown, a successor is published. Without lifecycle metadata at
+discovery time a consumer cannot distinguish a current artifact from a
+deprecated one, cannot learn an end-of-life date before committing to an
+integration, and cannot discover the recommended replacement or its
+migration guide. The Lifecycle extension enriches an entry with the
+software-lifecycle state of the artifact version it identifies, so
+consumers can filter deprecated or retired artifacts at discovery, plan
+around a known end-of-life date, and follow a producer-supplied migration
+path to a successor.
+
+The extension value is a JSON object appearing under the key
+`https://ai-catalog.org/extensions/lifecycle` in an entry's `extensions`
+map. It contains:
+
+`status`
+: OPTIONAL. A string naming the lifecycle state of this artifact version.
+  Because a catalog entry describes an artifact that is already
+  discoverable, every recommended value denotes a version a consumer can
+  actually reach; a not-yet-released state has no place here. This field
+  is open text; to ensure interoperability the following values are
+  RECOMMENDED: `"preview"` (released ahead of general availability for
+  evaluation, not yet fully supported), `"active"` (generally available
+  and supported — the default state of a healthy artifact), `"deprecated"`
+  (still available but scheduled for retirement, with a successor or
+  migration path), and `"retired"` (end-of-life: no longer supported and
+  SHOULD NOT be adopted, though the entry may remain listed as a tombstone
+  pointing to its successor).
+
+`releaseDate`
+: OPTIONAL. A string containing an ISO 8601 [[RFC3339]] `full-date` (e.g.
+  `"2026-03-15"`) or date-time on which this artifact version was
+  released. This is distinct from the entry's `updatedAt`, which records
+  when the catalog entry itself was last modified.
+
+`deprecated`
+: OPTIONAL. A Deprecation object (defined below) describing the
+  deprecation timeline, breaking changes, and recommended successor. It
+  SHOULD be present when `status` is `"deprecated"` or `"retired"`, and
+  SHOULD be absent otherwise.
+
+The Deprecation object contains:
+
+`replacedBy`
+: OPTIONAL. A string containing the `identifier` of the artifact that
+  supersedes this one. Because it is an artifact identifier, it is subject
+  to the same naming rule as a Catalog Entry's `identifier` (see
+  [Catalog Entry](#catalog-entry)): the `urn:air` structure is HIGHLY
+  RECOMMENDED and MUST be used for open or federated systems, so that the
+  successor resolves to the same identity wherever it is listed. The
+  successor MAY be a newer `version` of the same `identifier` (a version
+  bump) or a different `identifier` (a distinct successor artifact); it
+  SHOULD NOT equal the deprecated entry's own `identifier` and `version`
+  together.
+
+`deprecationDate`
+: OPTIONAL. A string containing an ISO 8601 [[RFC3339]] date or date-time
+  on which this artifact version became (or becomes) deprecated. A date in
+  the future announces an upcoming deprecation consumers can plan around.
+
+`endOfLifeDate`
+: OPTIONAL. A string containing an ISO 8601 [[RFC3339]] date or date-time
+  after which this artifact version is retired and SHOULD NOT be relied
+  upon. A date in the future is a commitment consumers can plan around.
+
+`breakingChanges`
+: OPTIONAL. An array of strings, each a human-readable description of a
+  breaking change a consumer must account for when migrating to the
+  successor.
+
+`migrationGuide`
+: OPTIONAL. A string containing a URL to documentation describing how to
+  migrate to the successor.
+
+The following rules apply:
+
+- Lifecycle metadata describes the artifact **version** identified by the
+  entry, not the logical artifact as a whole. When a catalog lists
+  multiple versions of the same `identifier` (see
+  [Multi-Version Entries](#multi-version-entries)), each versioned entry
+  MAY carry its own Lifecycle extension, so a v1 entry can be
+  `"deprecated"` while the v2 entry is `"active"`.
+- When `status` is `"deprecated"` or `"retired"`, producers SHOULD include
+  a `deprecated` object and SHOULD populate `replacedBy` or
+  `migrationGuide` (or both) so a consumer can act on the deprecation.
+- A consumer that does not understand the extension key MUST ignore it and
+  treat the entry as it would any other. This is guaranteed by the
+  existing extensions rule (see [Format and Key Naming](#format-and-key-naming)).
+- A consumer that DOES understand the extension MAY use it to filter or
+  rank entries at discovery — for example excluding `"retired"` artifacts,
+  warning on `"deprecated"` ones, or preferring the `replacedBy`
+  successor. A consumer MAY still choose a deprecated artifact
+  deliberately (e.g. for a short-lived task that completes before the
+  `endOfLifeDate`).
+- Because this is lifecycle metadata, not a trust claim, it is unsigned
+  unless it appears in a Trust Manifest's `extensions`; it MUST NOT be
+  treated as a security or support guarantee on its own. The dates and the
+  successor reference are producer assertions.
+
+For example, a deprecated v1 agent superseded by a v2 with a scheduled
+end-of-life:
+
+```json
+{
+  "identifier": "urn:air:acme.com:finance:invoice-processor",
+  "version": "1.0.0",
+  "type": "application/a2a-agent-card+json",
+  "url": "https://api.acme.com/agents/invoice/v1",
+  "tags": ["finance", "a2a"],
+  "extensions": {
+    "https://ai-catalog.org/extensions/lifecycle": {
+      "status": "deprecated",
+      "releaseDate": "2025-03-15",
+      "deprecated": {
+        "replacedBy": "urn:air:acme.com:finance:invoice-processor-v2",
+        "deprecationDate": "2026-09-01",
+        "endOfLifeDate": "2027-01-01",
+        "breakingChanges": [
+          "Authentication changed from API key to OAuth2",
+          "Response schema now uses ISO 8601 dates"
+        ],
+        "migrationGuide": "https://docs.acme.com/invoice-v2-migration"
+      }
+    }
+  }
+}
+```
+
+**Consumer behavior.** A consumer that understands the extension reads
+`status` to decide how to treat the entry at discovery: it MAY hide or
+de-rank `"retired"` and `"deprecated"` artifacts, surface the
+`endOfLifeDate` so an operator can plan a migration, and follow
+`replacedBy` to the successor entry (resolving it like any other
+`identifier`) and `migrationGuide` for the steps involved.
+
+Because `status` is open text, the recommended values are not exhaustive
+and a consumer MUST NOT reject an entry solely because its `status` is
+unrecognized. A consumer SHOULD NOT, however, silently discard an
+unrecognized value and treat the artifact as though no status were
+declared: that fails open, because a value such as `"sunset"` or
+`"end-of-support"` may signal retirement that a consumer would then
+overlook. Instead, a consumer SHOULD attempt to interpret an unrecognized
+value against the recommended states — an agent consumer, in particular,
+can map it semantically to the nearest recommended value (e.g. `"sunset"`
+→ `"deprecated"`). When it cannot interpret the value with confidence, a
+consumer SHOULD preserve and surface the raw value and treat the artifact
+conservatively (for example, excluding it from long-lived commitments)
+rather than assume it is `"active"`. This mirrors how unrecognized `type`
+values are handled — never a hard failure — while failing safe, since
+`status` qualifies an artifact the consumer can otherwise use rather than
+routing it.
+
+Lifecycle dates and the successor reference are producer assertions; a
+consumer that needs a supported-until guarantee corroborates them out of
+band rather than trusting the extension alone.
 
 # Version Handling
 
@@ -1489,7 +1659,15 @@ MUST treat it as untrusted input. In particular:
 
 Logo URLs SHOULD use Data URIs [[RFC2397]] to avoid leaking client
 information through image fetch requests. Publishers SHOULD carefully
-consider what information is included in `extensions` fields.
+consider what information is included in `extensions` fields. In
+particular, the Lifecycle extension's dates and `replacedBy` reference may
+disclose an unreleased successor or an internal retirement schedule ahead
+of a public announcement, so publishers SHOULD expose only those lifecycle
+details intended for the catalog's audience. Furthermore, lifecycle dates
+and the successor reference are unsigned producer assertions unless carried
+in a signed Trust Manifest, so a consumer needing a supported-until
+guarantee MUST corroborate them out of band rather than trusting the
+extension alone.
 
 # Data Model Overview
 
@@ -1688,6 +1866,28 @@ Publisher = {
   identifier: text,
   displayName: text,
   ? identityType: text
+}
+```
+
+## Lifecycle Extension
+
+The following CDDL is INFORMATIVE. It describes the value of the
+`https://ai-catalog.org/extensions/lifecycle` entry in an `extensions`
+map (see [Lifecycle Metadata Extension](#lifecycle-metadata-extension)):
+
+```
+LifecycleExtension = {
+  ? status: text,
+  ? releaseDate: text,
+  ? deprecated: Deprecation
+}
+
+Deprecation = {
+  ? replacedBy: text,
+  ? deprecationDate: text,
+  ? endOfLifeDate: text,
+  ? breakingChanges: [+ text],
+  ? migrationGuide: text
 }
 ```
 


### PR DESCRIPTION
## Summary

This PR resolves [#65](https://github.com/Agent-Card/ai-catalog/issues/65)
(communicate an artifact's software-lifecycle state at discovery time) by
adding an **official extension** —
`https://ai-catalog.org/extensions/lifecycle` — rather than a native
`lifecycle` field on the Catalog Entry as the original issue proposed.

A Catalog Entry carries `version` (which revision this is) and `updatedAt`
(when the entry last changed), but nothing that expresses *where that
revision sits in its lifecycle*: whether it is a preview, generally
available, deprecated with a scheduled end-of-life, or already retired —
nor how a consumer should move off it. Agents evolve: a v1 is superseded by
a breaking v2, an endpoint is scheduled for shutdown, a successor ships with
a migration guide. The extension lets a publisher advertise that state on a
**per-version** entry so a consumer — an agent planner or a governance tool
— can filter deprecated or retired artifacts at discovery, plan around a
known end-of-life, and follow a producer-supplied migration path to a
successor **before** committing to an integration.

Because the extension is additive and unrecognized `extensions` keys are
ignored, it needs **no `specVersion` change** — a catalog carrying it
remains a conformant `1.0` document.

## Changes Included

1. **`adr/0023-lifecycle-metadata-extension.md`** (new) — records the
   decision to implement #65 as an official extension rather than a native
   entry field, consistent with the closed-core philosophy of
   [ADR-0012](adr/0012-extensibility-via-metadata.md); documents the
   open-text `status` rationale, the `replacedBy` naming rule, and the
   interpret-then-fail-safe rule for unrecognized values.
2. **`specification/ai-catalog.md`**:
   - Registered the extension in the **Official Extensions** list alongside
     `metadata`.
   - Added the **Lifecycle Metadata Extension** section: value structure
     (`status`, `releaseDate`, and a `deprecated` object carrying
     `replacedBy`, `deprecationDate`, `endOfLifeDate`, `breakingChanges`,
     `migrationGuide`), the per-version scoping rule, an example, and a
     **Consumer behavior** paragraph.
   - Added an informative **CDDL** block for the extension value.
   - Added a **Privacy Considerations** note on disclosing unreleased
     successors / retirement schedules and on unsigned producer assertions.
3. **Developer docs** — a new annotated example
   (`docs/examples/lifecycle-metadata.md`), an authoring section in
   *Creating a Catalog*, a filtering section in *Consuming Catalogs*, plus
   cross-links and a nav entry.

## Reconciling the original proposal

The proposal in #65 predates several current conventions; the extension
uses today's forms:

| Proposal (outdated) | This PR (current) |
|---|---|
| `urn:ai:…` | `urn:air:{publisher}:{namespace}:{name}` (ADR-0015) |
| native `lifecycle` field on the entry | official `extensions` entry (keeps the core schema closed) |
| `replacedBy` pointing at the deprecated artifact's own identifier | `replacedBy` pointing at the distinct successor identifier |
| lifecycle attached to the logical artifact | lifecycle scoped to the **version** the entry identifies (a `deprecated` v1 alongside an `active` v2) |

## Design notes

- **Per-version, not per-artifact.** Lifecycle describes the version the
  entry identifies; within a multi-version listing each versioned entry may
  carry its own status.
- **`status` is open text, not a closed enum.** RECOMMENDED values are
  `preview`, `active`, `deprecated`, and `retired` — each a state a consumer
  can actually reach. A not-yet-released "planned" state is deliberately
  excluded: a catalog entry exists because the artifact is discoverable, and
  an unreleased version has no consumable endpoint to list.
- **Unrecognized status fails safe, not open.** A consumer MUST NOT reject
  an entry solely because its `status` is unrecognized, but MUST NOT
  silently discard the value either — a value such as `sunset` may signal a
  retirement a consumer would then miss. A consumer SHOULD interpret it
  against the recommended states (an agent consumer can do so semantically)
  and, when it cannot, treat the artifact conservatively rather than assume
  it is `active`. This mirrors the spec's open-text treatment of `type` and
  `identifier` while keeping unrecognized values safe.
- **`replacedBy` follows the core identifier rule.** It is an artifact
  identifier, so the `urn:air` structure is HIGHLY RECOMMENDED and MUST be
  used for open or federated systems — the same rule as a Catalog Entry
  `identifier`.
- **Lifecycle metadata is not a support guarantee.** The dates and the
  successor reference are unsigned producer assertions unless carried in a
  signed Trust Manifest; a consumer that needs a supported-until guarantee
  corroborates them out of band, not via this extension.

## Interoperability impact

No change to interoperability expectations for existing catalogs. The core
schema, CDDL for core types, conformance levels, and `specVersion` are all
unchanged; a consumer that does not implement the extension ignores it
without error, exactly as for any unrecognized `extensions` key.

## Non-goals

- A lifecycle **enforcement** mechanism or support SLA — this is advisory
  discovery metadata only.
- Promoting lifecycle to a **core field** — deliberately kept an extension
  per ADR-0012 / ADR-0023.
- A closed `status` enum — rejected as less flexible and misaligned with the
  spec's open-text fields.

## Validation

- `uv run --locked python tools/build_spec.py specification/ai-catalog.md dist/index.html --config specification/respec-config.json` — passes.
- `uv run --python 3.12 --locked --group docs mkdocs build --strict` — passes, no broken links.
- All lifecycle-bearing JSON examples validated.